### PR TITLE
issue #29: lagom-pb update

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "1.5.1"
+version = "2.6.2"
 style = IntelliJ
 
 align = none
@@ -7,7 +7,7 @@ binPack.literalArgumentLists = true
 binPack.parentConstructors = false
 continuationIndent.defnSite = 4
 danglingParentheses = true
-docstrings = Javadoc
+docstrings = JavaDoc
 includeCurlyBraceInSelectChains = true
 lineEndings = unix
 maxColumn = 120

--- a/api/src/main/scala/com/namely/chiefofstate/api/ChiefOfStateService.scala
+++ b/api/src/main/scala/com/namely/chiefofstate/api/ChiefOfStateService.scala
@@ -4,9 +4,9 @@ import akka.NotUsed
 import com.lightbend.lagom.scaladsl.api.{Descriptor, ServiceCall}
 import com.lightbend.lagom.scaladsl.api.Service.restCall
 import com.lightbend.lagom.scaladsl.api.transport.Method
-import lagompb.LagompbService
+import io.superflat.lagompb.BaseService
 
-trait ChiefOfStateService extends LagompbService {
+trait ChiefOfStateService extends BaseService {
 
   def handleCommand(): ServiceCall[NotUsed, String]
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   // Package versions
   object Versions {
     val scala213 = "2.13.1"
-    val lagompVersion = "0.2.0"
+    val lagompVersion = "0.4.0"
     val akkaVersion: String = "2.6.6"
     val scalapbCommonProtosVersion: String = "1.18.0-0"
     val kanelaAgentVersion = "1.0.5"

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.32")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.3"
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.34")
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.7"

--- a/service/src/main/scala/com/namely/chiefofstate/ChiefOfStateAggregate.scala
+++ b/service/src/main/scala/com/namely/chiefofstate/ChiefOfStateAggregate.scala
@@ -3,7 +3,7 @@ package com.namely.chiefofstate
 import akka.actor.ActorSystem
 import com.namely.protobuf.chief_of_state.cos_persistence.State
 import com.typesafe.config.Config
-import lagompb.{LagompbAggregate, LagompbCommandHandler, LagompbEventHandler}
+import io.superflat.lagompb.{AggregateRoot, CommandHandler, EventHandler}
 import scalapb.GeneratedMessageCompanion
 
 /**
@@ -17,9 +17,9 @@ import scalapb.GeneratedMessageCompanion
 class ChiefOfStateAggregate(
     actorSystem: ActorSystem,
     config: Config,
-    commandHandler: LagompbCommandHandler[State],
-    eventHandler: LagompbEventHandler[State]
-) extends LagompbAggregate[State](actorSystem, commandHandler, eventHandler) {
+    commandHandler: CommandHandler[State],
+    eventHandler: EventHandler[State]
+) extends AggregateRoot[State](actorSystem, commandHandler, eventHandler) {
   // $COVERAGE-OFF$
   override def aggregateName: String = "chiefOfState"
 

--- a/service/src/main/scala/com/namely/chiefofstate/ChiefOfStateApplication.scala
+++ b/service/src/main/scala/com/namely/chiefofstate/ChiefOfStateApplication.scala
@@ -16,14 +16,15 @@ import com.namely.protobuf.chief_of_state.cos_persistence.State
 import com.namely.protobuf.chief_of_state.cos_readside_handler.ReadSideHandlerServiceClient
 import com.namely.protobuf.chief_of_state.cos_writeside_handler.WriteSideHandlerServiceClient
 import com.softwaremill.macwire.wire
-import lagompb.{LagompbAggregate, LagompbApplication, LagompbCommandHandler, LagompbEventHandler}
+import io.superflat.lagompb.{AggregateRoot, BaseApplication, CommandHandler, EventHandler}
+import io.superflat.lagompb.encryption.{NoEncryption, ProtoEncryption}
 
 /**
  * ChiefOfState application
  *
  * @param context
  */
-abstract class ChiefOfStateApplication(context: LagomApplicationContext) extends LagompbApplication(context) {
+abstract class ChiefOfStateApplication(context: LagomApplicationContext) extends BaseApplication(context) {
   // $COVERAGE-OFF$
 
   // wiring up the grpc for the writeSide client
@@ -41,12 +42,15 @@ abstract class ChiefOfStateApplication(context: LagomApplicationContext) extends
       writeSideHandlerServiceClient.close()
     }
 
-  // wire up the various event and command handler
-  lazy val eventHandler: LagompbEventHandler[State] = wire[ChiefOfStateEventHandler]
-  lazy val commandHandler: LagompbCommandHandler[State] = wire[ChiefOfStateCommandHandler]
-  lazy val aggregate: LagompbAggregate[State] = wire[ChiefOfStateAggregate]
+  // let us wire up for now the default encryption
+  lazy val encryption: ProtoEncryption = NoEncryption
 
-  override def aggregateRoot: LagompbAggregate[_] = aggregate
+  // wire up the various event and command handler
+  lazy val eventHandler: EventHandler[State] = wire[ChiefOfStateEventHandler]
+  lazy val commandHandler: CommandHandler[State] = wire[ChiefOfStateCommandHandler]
+  lazy val aggregate: AggregateRoot[State] = wire[ChiefOfStateAggregate]
+
+  override def aggregateRoot: AggregateRoot[_] = aggregate
 
   override def server: LagomServer =
     serverFor[ChiefOfStateService](wire[ChiefOfStateServiceImpl])
@@ -76,6 +80,7 @@ abstract class ChiefOfStateApplication(context: LagomApplicationContext) extends
  * ChiefOfStateApplicationLoader boostraps the application at runtime
  */
 class ChiefOfStateApplicationLoader extends LagomApplicationLoader {
+
   // $COVERAGE-OFF$
   override def load(context: LagomApplicationContext): LagomApplication =
     new ChiefOfStateApplication(context) with AkkaDiscoveryComponents

--- a/service/src/main/scala/com/namely/chiefofstate/ChiefOfStateCommandHandler.scala
+++ b/service/src/main/scala/com/namely/chiefofstate/ChiefOfStateCommandHandler.scala
@@ -17,8 +17,8 @@ import com.namely.protobuf.chief_of_state.cos_writeside_handler.HandleCommandRes
   Reply
 }
 import io.grpc.Status
-import lagompb.{LagompbCommand, LagompbCommandHandler}
-import lagompb.core._
+import io.superflat.lagompb.{Command, CommandHandler}
+import io.superflat.lagompb.protobuf.core._
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.{Await, Future}
@@ -36,7 +36,7 @@ class ChiefOfStateCommandHandler(
     actorSystem: ActorSystem,
     writeSideHandlerServiceClient: WriteSideHandlerServiceClient,
     handlerSetting: ChiefOfStateHandlerSetting
-) extends LagompbCommandHandler[State](actorSystem) {
+) extends CommandHandler[State](actorSystem) {
 
   final val log: Logger = LoggerFactory.getLogger(getClass)
 
@@ -48,11 +48,7 @@ class ChiefOfStateCommandHandler(
    * @param priorEventMeta
    * @return
    */
-  override def handle(
-      command: LagompbCommand,
-      priorState: State,
-      priorEventMeta: MetaData
-  ): Try[CommandHandlerResponse] = {
+  override def handle(command: Command, priorState: State, priorEventMeta: MetaData): Try[CommandHandlerResponse] = {
     Try(
       writeSideHandlerServiceClient.handleCommand(
         HandleCommandRequest()

--- a/service/src/main/scala/com/namely/chiefofstate/ChiefOfStateEventHandler.scala
+++ b/service/src/main/scala/com/namely/chiefofstate/ChiefOfStateEventHandler.scala
@@ -8,8 +8,8 @@ import com.namely.protobuf.chief_of_state.cos_writeside_handler.{
   HandleEventResponse,
   WriteSideHandlerServiceClient
 }
-import lagompb.{LagompbEventHandler, LagompbException}
-import lagompb.core.MetaData
+import io.superflat.lagompb.{EventHandler, GlobalException}
+import io.superflat.lagompb.protobuf.core.MetaData
 import org.slf4j.{Logger, LoggerFactory}
 import scalapb.GeneratedMessage
 
@@ -28,7 +28,7 @@ class ChiefOfStateEventHandler(
     actorSystem: ActorSystem,
     writeSideHandlerServiceClient: WriteSideHandlerServiceClient,
     handlerSetting: ChiefOfStateHandlerSetting
-) extends LagompbEventHandler[State](actorSystem) {
+) extends EventHandler[State](actorSystem) {
 
   final val log: Logger = LoggerFactory.getLogger(getClass)
 
@@ -49,13 +49,13 @@ class ChiefOfStateEventHandler(
     ) match {
 
       case Failure(e) =>
-        throw new LagompbException(e.getMessage)
+        throw new GlobalException(e.getMessage)
 
       case Success(eventualEventResponse: Future[HandleEventResponse]) =>
         Try {
           Await.result(eventualEventResponse, Duration.Inf)
         } match {
-          case Failure(exception) => throw new LagompbException(exception.getMessage)
+          case Failure(exception) => throw new GlobalException(exception.getMessage)
           case Success(handleEventResponse: HandleEventResponse) =>
             val stateFQN: String = ChiefOfStateHelper.getProtoFullyQualifiedName(handleEventResponse.getResultingState)
 
@@ -67,7 +67,7 @@ class ChiefOfStateEventHandler(
 
               priorState.update(_.currentState := handleEventResponse.getResultingState)
             } else {
-              throw new LagompbException(
+              throw new GlobalException(
                 s"[ChiefOfState]: command handler state to perist $stateFQN is not configured. Failing request"
               )
             }

--- a/service/src/main/scala/com/namely/chiefofstate/ChiefOfStateServiceImpl.scala
+++ b/service/src/main/scala/com/namely/chiefofstate/ChiefOfStateServiceImpl.scala
@@ -7,7 +7,7 @@ import com.lightbend.lagom.scaladsl.api.ServiceCall
 import com.lightbend.lagom.scaladsl.persistence.PersistentEntityRegistry
 import com.namely.chiefofstate.api.ChiefOfStateService
 import com.namely.protobuf.chief_of_state.cos_persistence.State
-import lagompb.{LagompbAggregate, LagompbServiceImpl}
+import io.superflat.lagompb.{AggregateRoot, BaseServiceImpl}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,14 +16,15 @@ class ChiefOfStateServiceImpl(
     actorSystem: ActorSystem,
     clusterSharding: ClusterSharding,
     persistentEntityRegistry: PersistentEntityRegistry,
-    aggregate: LagompbAggregate[State]
+    aggregate: AggregateRoot[State]
 )(implicit ec: ExecutionContext)
-    extends LagompbServiceImpl(clusterSharding, persistentEntityRegistry, aggregate)
+    extends BaseServiceImpl(clusterSharding, persistentEntityRegistry, aggregate)
     with ChiefOfStateService {
 
-  override def handleCommand(): ServiceCall[NotUsed, String] = ServiceCall { _ =>
-    Future.successful("Welcome to Chief Of State. The gRPC distributed event sourcing application!!!")
-  }
+  override def handleCommand(): ServiceCall[NotUsed, String] =
+    ServiceCall { _ =>
+      Future.successful("Welcome to Chief Of State. The gRPC distributed event sourcing application!!!")
+    }
 
   override def aggregateStateCompanion: GeneratedMessageCompanion[_ <: GeneratedMessage] = State
 }

--- a/service/src/test/scala/com/namely/chiefofstate/ChiefOfStateCommandHandlerSpec.scala
+++ b/service/src/test/scala/com/namely/chiefofstate/ChiefOfStateCommandHandlerSpec.scala
@@ -11,9 +11,9 @@ import com.namely.protobuf.chief_of_state.cos_writeside_handler._
 import com.namely.protobuf.chief_of_state.cos_writeside_handler.HandleCommandResponse.ResponseType
 import com.namely.protobuf.chief_of_state.tests.{Account, AccountOpened, OpenAccount}
 import io.grpc.Status
-import lagompb.core._
-import lagompb.testkit.LagompbSpec
-import lagompb.LagompbCommand
+import io.superflat.lagompb.protobuf.core._
+import io.superflat.lagompb.testkit.LagompbSpec
+import io.superflat.lagompb.Command
 import org.scalamock.scalatest.MockFactory
 
 import scala.concurrent.Future
@@ -35,7 +35,7 @@ class ChiefOfStateCommandHandlerSpec extends LagompbSpec with MockFactory {
 
       val handlerSetting: ChiefOfStateHandlerSetting = ChiefOfStateHandlerSetting(stateProto, eventsProtos)
 
-      val cmd = LagompbCommand(
+      val cmd = Command(
         Any.pack(
           OpenAccount()
             .withAccountNumber(accountNumber)
@@ -96,7 +96,7 @@ class ChiefOfStateCommandHandlerSpec extends LagompbSpec with MockFactory {
 
       val handlerSetting: ChiefOfStateHandlerSetting = ChiefOfStateHandlerSetting(stateProto, eventsProtos)
 
-      val cmd = LagompbCommand(
+      val cmd = Command(
         Any.pack(
           OpenAccount()
             .withAccountNumber(accountNumber)
@@ -163,7 +163,7 @@ class ChiefOfStateCommandHandlerSpec extends LagompbSpec with MockFactory {
 
       val handlerSetting: ChiefOfStateHandlerSetting = ChiefOfStateHandlerSetting(stateProto, eventsProtos)
 
-      val cmd = LagompbCommand(
+      val cmd = Command(
         Any.pack(
           OpenAccount()
             .withAccountNumber(accountNumber)
@@ -221,7 +221,7 @@ class ChiefOfStateCommandHandlerSpec extends LagompbSpec with MockFactory {
 
       val handlerSetting: ChiefOfStateHandlerSetting = ChiefOfStateHandlerSetting(stateProto, eventsProtos)
 
-      val cmd = LagompbCommand(
+      val cmd = Command(
         Any.pack(
           OpenAccount()
             .withAccountNumber(accountNumber)
@@ -280,7 +280,7 @@ class ChiefOfStateCommandHandlerSpec extends LagompbSpec with MockFactory {
 
       val handlerSetting: ChiefOfStateHandlerSetting = ChiefOfStateHandlerSetting(stateProto, eventsProtos)
 
-      val cmd = LagompbCommand(
+      val cmd = Command(
         Any.pack(
           OpenAccount()
             .withAccountNumber(accountNumber)
@@ -334,7 +334,7 @@ class ChiefOfStateCommandHandlerSpec extends LagompbSpec with MockFactory {
 
       val handlerSetting: ChiefOfStateHandlerSetting = ChiefOfStateHandlerSetting(stateProto, eventsProtos)
 
-      val cmd = LagompbCommand(
+      val cmd = Command(
         Any.pack(
           OpenAccount()
             .withAccountNumber(accountNumber)
@@ -388,7 +388,7 @@ class ChiefOfStateCommandHandlerSpec extends LagompbSpec with MockFactory {
 
       val handlerSetting: ChiefOfStateHandlerSetting = ChiefOfStateHandlerSetting(stateProto, eventsProtos)
 
-      val cmd = LagompbCommand(
+      val cmd = Command(
         Any.pack(
           OpenAccount()
             .withAccountNumber(accountNumber)

--- a/service/src/test/scala/com/namely/chiefofstate/ChiefOfStateEventHandlerSpec.scala
+++ b/service/src/test/scala/com/namely/chiefofstate/ChiefOfStateEventHandlerSpec.scala
@@ -13,9 +13,9 @@ import com.namely.protobuf.chief_of_state.cos_writeside_handler.{
 }
 import com.namely.protobuf.chief_of_state.tests.{Account, AccountOpened}
 import io.grpc.Status
-import lagompb.core.MetaData
-import lagompb.testkit.LagompbSpec
-import lagompb.LagompbException
+import io.superflat.lagompb.protobuf.core.MetaData
+import io.superflat.lagompb.testkit.LagompbSpec
+import io.superflat.lagompb.GlobalException
 import org.scalamock.scalatest.MockFactory
 
 import scala.concurrent.Future
@@ -121,7 +121,7 @@ class ChiefOfStateEventHandlerSpec extends LagompbSpec with MockFactory {
         )
 
       val eventHandler: ChiefOfStateEventHandler = new ChiefOfStateEventHandler(null, mockGrpcClient, handlerSetting)
-      a[LagompbException] shouldBe thrownBy(
+      a[GlobalException] shouldBe thrownBy(
         eventHandler.handle(Event().withEvent(Any.pack(event)), priorState, eventMeta)
       )
     }
@@ -162,7 +162,7 @@ class ChiefOfStateEventHandlerSpec extends LagompbSpec with MockFactory {
         .returning(Future.failed(new GrpcServiceException(Status.INTERNAL)))
 
       val eventHandler: ChiefOfStateEventHandler = new ChiefOfStateEventHandler(null, mockGrpcClient, handlerSetting)
-      a[LagompbException] shouldBe thrownBy(
+      a[GlobalException] shouldBe thrownBy(
         eventHandler.handle(Event().withEvent(Any.pack(event)), priorState, eventMeta)
       )
     }
@@ -203,7 +203,7 @@ class ChiefOfStateEventHandlerSpec extends LagompbSpec with MockFactory {
         .throws(new RuntimeException("broken"))
 
       val eventHandler: ChiefOfStateEventHandler = new ChiefOfStateEventHandler(null, mockGrpcClient, handlerSetting)
-      a[LagompbException] shouldBe thrownBy(
+      a[GlobalException] shouldBe thrownBy(
         eventHandler.handle(Event().withEvent(Any.pack(event)), priorState, eventMeta)
       )
     }

--- a/service/src/test/scala/com/namely/chiefofstate/ChiefOfStateHandlerSettingSpec.scala
+++ b/service/src/test/scala/com/namely/chiefofstate/ChiefOfStateHandlerSettingSpec.scala
@@ -1,7 +1,7 @@
 package com.namely.chiefofstate
 
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
-import lagompb.testkit.LagompbSpec
+import io.superflat.lagompb.testkit.LagompbSpec
 
 class ChiefOfStateHandlerSettingSpec extends LagompbSpec {
 

--- a/service/src/test/scala/com/namely/chiefofstate/ChiefOfStateReadProcessorSpec.scala
+++ b/service/src/test/scala/com/namely/chiefofstate/ChiefOfStateReadProcessorSpec.scala
@@ -3,8 +3,8 @@ package com.namely.chiefofstate
 import java.util.UUID
 
 import akka.Done
-import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.adapter._
 import akka.grpc.GrpcServiceException
 import com.google.protobuf.any.Any
 import com.namely.protobuf.chief_of_state.cos_common
@@ -16,30 +16,33 @@ import com.namely.protobuf.chief_of_state.cos_readside_handler.{
 }
 import com.namely.protobuf.chief_of_state.tests.{Account, AccountOpened}
 import io.grpc.Status
-import lagompb.core.MetaData
-import lagompb.testkit.LagompbActorTestKit
-import lagompb.LagompbException
+import io.superflat.lagompb.protobuf.core.MetaData
+import io.superflat.lagompb.testkit.LagompbActorTestKit
+import io.superflat.lagompb.GlobalException
+import io.superflat.lagompb.encryption.NoEncryption
 import org.scalamock.scalatest.MockFactory
 import slick.dbio.DBIO
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class ChiefOfStateReadProcessorSpec extends LagompbActorTestKit(s"""
+class ChiefOfStateReadProcessorSpec
+    extends LagompbActorTestKit(s"""
     akka {
       actor {
         serialize-messages = on
         serializers {
           proto = "akka.remote.serialization.ProtobufSerializer"
-          cmdSerializer = "lagompb.LagompbCommandSerde"
+         cmdSerializer = "io.superflat.lagompb.CommandSerializer"
         }
         serialization-bindings {
           "scalapb.GeneratedMessage" = proto
-          "lagompb.LagompbCommand" = cmdSerializer
+         "io.superflat.lagompb.Command" = cmdSerializer
         }
       }
     }
-    """) with MockFactory {
+    """)
+    with MockFactory {
 
   val sys: ActorSystem[Nothing] = testKit.system
 
@@ -85,7 +88,8 @@ class ChiefOfStateReadProcessorSpec extends LagompbActorTestKit(s"""
           )
         )
 
-      val readSideProcessor = new ChiefOfStateReadProcessor(testKit.system.toClassic, mockGrpcClient, handlerSetting)
+      val readSideProcessor =
+        new ChiefOfStateReadProcessor(NoEncryption, testKit.system.toClassic, mockGrpcClient, handlerSetting)
       val result: DBIO[Done] =
         readSideProcessor.handle(Event().withEvent(Any.pack(event)), state, eventMeta)
       result.map(r => r shouldBe (Done))
@@ -131,8 +135,9 @@ class ChiefOfStateReadProcessorSpec extends LagompbActorTestKit(s"""
           )
         )
 
-      val readSideProcessor = new ChiefOfStateReadProcessor(testKit.system.toClassic, mockGrpcClient, handlerSetting)
-      an[LagompbException] shouldBe thrownBy(
+      val readSideProcessor =
+        new ChiefOfStateReadProcessor(NoEncryption, testKit.system.toClassic, mockGrpcClient, handlerSetting)
+      an[GlobalException] shouldBe thrownBy(
         readSideProcessor.handle(Event().withEvent(Any.pack(event)), state, eventMeta)
       )
     }
@@ -172,8 +177,9 @@ class ChiefOfStateReadProcessorSpec extends LagompbActorTestKit(s"""
         )
         .throws(new RuntimeException("broken"))
 
-      val readSideProcessor = new ChiefOfStateReadProcessor(testKit.system.toClassic, mockGrpcClient, handlerSetting)
-      an[LagompbException] shouldBe thrownBy(
+      val readSideProcessor =
+        new ChiefOfStateReadProcessor(NoEncryption, testKit.system.toClassic, mockGrpcClient, handlerSetting)
+      an[GlobalException] shouldBe thrownBy(
         readSideProcessor.handle(Event().withEvent(Any.pack(event)), state, eventMeta)
       )
     }
@@ -213,8 +219,9 @@ class ChiefOfStateReadProcessorSpec extends LagompbActorTestKit(s"""
         )
         .returning(Future.failed(new GrpcServiceException(Status.NOT_FOUND)))
 
-      val readSideProcessor = new ChiefOfStateReadProcessor(testKit.system.toClassic, mockGrpcClient, handlerSetting)
-      an[LagompbException] shouldBe thrownBy(
+      val readSideProcessor =
+        new ChiefOfStateReadProcessor(NoEncryption, testKit.system.toClassic, mockGrpcClient, handlerSetting)
+      an[GlobalException] shouldBe thrownBy(
         readSideProcessor.handle(Event().withEvent(Any.pack(event)), state, eventMeta)
       )
     }
@@ -254,8 +261,9 @@ class ChiefOfStateReadProcessorSpec extends LagompbActorTestKit(s"""
         )
         .throws(new GrpcServiceException(Status.INVALID_ARGUMENT))
 
-      val readSideProcessor = new ChiefOfStateReadProcessor(testKit.system.toClassic, mockGrpcClient, handlerSetting)
-      an[LagompbException] shouldBe thrownBy(
+      val readSideProcessor =
+        new ChiefOfStateReadProcessor(NoEncryption, testKit.system.toClassic, mockGrpcClient, handlerSetting)
+      an[GlobalException] shouldBe thrownBy(
         readSideProcessor.handle(Event().withEvent(Any.pack(event)), state, eventMeta)
       )
     }
@@ -276,8 +284,9 @@ class ChiefOfStateReadProcessorSpec extends LagompbActorTestKit(s"""
         .withAccountNumber(accountNumber)
         .withAccountUuid(accouuntId)
 
-      val readSideProcessor = new ChiefOfStateReadProcessor(testKit.system.toClassic, null, handlerSetting)
-      an[LagompbException] shouldBe thrownBy(readSideProcessor.handle(Any.pack(event), state, eventMeta))
+      val readSideProcessor =
+        new ChiefOfStateReadProcessor(NoEncryption, testKit.system.toClassic, null, handlerSetting)
+      an[GlobalException] shouldBe thrownBy(readSideProcessor.handle(Any.pack(event), state, eventMeta))
     }
   }
 }


### PR DESCRIPTION
Changes:
- upgrades to lagom-pb 0.4.0
- uses default lagom-pb encryptor
- changes imports to `io.superflat.lagompb`

Issues:
- resolves #29