### PR TITLE
Issue-58: Optional Encryptors for lagom-pb v0.6

### DIFF
--- a/service/src/main/resources/application.conf
+++ b/service/src/main/resources/application.conf
@@ -257,7 +257,8 @@ chief-of-state {
 	encryption {
 		# lagom-pb ProtoEncryption used for lagom-pb event/snapshot adapters
 		# must implement io.superflat.lagompb.encryption.ProtoEncryption
-		encryption-class = "io.superflat.lagompb.encryption.NoEncryption"
+		# or leave as empty string if no encryption desired
+		encryption-class = ""
 		encryption-class = ${?COS_ENCRYPTION_CLASS}
 	}
 }

--- a/service/src/test/scala/com/namely/chiefofstate/EncryptionSettingSpec.scala
+++ b/service/src/test/scala/com/namely/chiefofstate/EncryptionSettingSpec.scala
@@ -2,30 +2,32 @@ package com.namely.chiefofstate
 
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import io.superflat.lagompb.testkit.LagompbSpec
+import io.superflat.lagompb.encryption.NoEncryption
 
-import scala.util.Try
+import scala.util.{Try, Success}
 
 class EncryptionSettingSpec extends LagompbSpec {
 
   "Chief-Of-State encryption settings" should {
 
-    "fail to load settings due to missing values" in {
+    "fail to load settings due to missing setting key" in {
       val config: Config = ConfigFactory.empty()
       an[RuntimeException] shouldBe thrownBy(EncryptionSetting(config))
     }
 
-    "fail to load settings due to empty values" in {
+    "defaults to None when no encryption value set" in {
       val config: Config = ConfigFactory
         .empty()
         .withValue(EncryptionSetting.SETTING_KEY, ConfigValueFactory.fromAnyRef(""))
 
-      an[RuntimeException] shouldBe thrownBy(EncryptionSetting(config))
+      EncryptionSetting(config) shouldBe(EncryptionSetting(encryption=None))
     }
 
     "fail to load settings due to unknown encryption class" in {
       val config: Config = ConfigFactory
         .empty()
         .withValue(EncryptionSetting.SETTING_KEY, ConfigValueFactory.fromAnyRef("not.an.encryptor"))
+
       an[RuntimeException] shouldBe thrownBy(EncryptionSetting(config))
     }
 
@@ -39,7 +41,7 @@ class EncryptionSettingSpec extends LagompbSpec {
 
       val actual: Try[EncryptionSetting] = Try(EncryptionSetting(config))
 
-      actual.map(_.encryption).toOption shouldBe (Some(io.superflat.lagompb.encryption.NoEncryption))
+      actual shouldBe Success(EncryptionSetting(Some(NoEncryption)))
     }
   }
 }


### PR DESCRIPTION
This PR prepares COS for [lagom-pb v0.6](https://github.com/super-flat/lagom-pb/releases/tag/v0.6-alpha.1) by making the encryption setting default to empty.

resolves #58 

Relates to PR #56  for #49 