### PR TITLE
Convert to alpine base image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import play.grpc.gen.scaladsl.{PlayScalaClientCodeGenerator, PlayScalaServerCodeGenerator}
 
-enablePlugins(JavaAppPackaging, AshScriptPlugin)
+enablePlugins(DockerComposePlugin)
 dockerImageCreationTask := (Docker / publishLocal in `chiefofstate`).value
 
 lazy val root = project
@@ -21,11 +21,7 @@ lazy val `chiefofstate` = project
   .enablePlugins(PlayAkkaHttp2Support)
   .enablePlugins(LagomImpl)
   .enablePlugins(LagomAkka)
-  .settings(
-    name := "chiefofstate",
-    javaAgents += Dependencies.Compile.KanelaAgent,
-    dockerBaseImage := "openjdk:8-jre-alpine"
-  )
+  .settings(name := "chiefofstate", javaAgents += Dependencies.Compile.KanelaAgent)
   .dependsOn(protogen, api)
 
 lazy val protogen = project


### PR DESCRIPTION
Changes COS to use the 8-jre-alpine image. Locally, this reduced the image build by 100MB, and runs with the python sample app.

I'd still like to get it to use the [AshScriptPlugin](https://www.scala-sbt.org/sbt-native-packager/archetypes/misc_archetypes.html) so we don't have to install bash, but bash seems to only occupy 6MB, so not a blocker.