### PR TITLE
Revert "Convert to alpine base image (#81)"

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -50,16 +50,14 @@ docker-prep:
 
 docker-build:
     # bundle into a slimmer, runnable container
-    FROM openjdk:8-jre-alpine
+    FROM openjdk:8-jre-slim
 
     ARG VERSION=dev
 
     USER root
 
-    RUN apk add --no-cache bash
-
     # create cos user for the service
-    RUN adduser -S cos -s /bin/false
+    RUN groupadd -r cos && useradd --gid cos -r --shell /bin/false cos
 
     # copy over files
     WORKDIR /opt/docker


### PR DESCRIPTION
Reverting the alpine sync, as the image was only 10mb smaller and quay reported 3 security issues.

This reverts commit e4767500baf51af43032823d3a45ed7f61457119.