### PR TITLE
Use alpine image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import play.grpc.gen.scaladsl.{PlayScalaClientCodeGenerator, PlayScalaServerCodeGenerator}
 
-enablePlugins(JavaAppPackaging, AshScriptPlugin)
+enablePlugins(DockerComposePlugin)
 dockerImageCreationTask := (Docker / publishLocal in `chiefofstate`).value
 
 lazy val root = project
@@ -21,11 +21,7 @@ lazy val `chiefofstate` = project
   .enablePlugins(PlayAkkaHttp2Support)
   .enablePlugins(LagomImpl)
   .enablePlugins(LagomAkka)
-  .settings(
-    name := "chiefofstate",
-    javaAgents += Dependencies.Compile.KanelaAgent,
-    dockerBaseImage := "openjdk:8-jre-alpine"
-  )
+  .settings(name := "chiefofstate", javaAgents += Dependencies.Compile.KanelaAgent)
   .dependsOn(protogen, api)
 
 lazy val protogen = project


### PR DESCRIPTION
This PR converts COS to use an alpine base image. Leaving this here for now, but we should play with it more. It didn't reduce the image size as much as I'd like, and introduced a few security issues.

originally tested in #81 