### PR TITLE
Updates to v1 Migration to address failures

### DIFF
--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/DbUtil.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/DbUtil.scala
@@ -25,7 +25,9 @@ object DbUtil {
    */
   def tableExists(dbConfig: DatabaseConfig[JdbcProfile], tableName: String): Boolean = {
     val tables: Seq[MTable] = Await.result(dbConfig.db.run(MTable.getTables), Duration.Inf)
-    tables.exists(_.name.name.equals(tableName))
+    tables
+      .filter(_.tableType == "TABLE")
+      .exists(_.name.name.equals(tableName))
   }
 
   /**

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
@@ -53,18 +53,6 @@ case class V1(
     }
   }
 
-  override def afterUpgrade(): Try[Unit] = {
-    // get the correct table name
-    val table: String = transformTableName()
-    Try {
-      if (!DbUtil.tableExists(projectionJdbcConfig, Migrator.COS_MIGRATIONS_TABLE)) {
-        log.info(s"dropping the read side offset store from the old database connection")
-        DbUtil.dropTableIfExists(table, projectionJdbcConfig)
-      }
-      log.info(s"ChiefOfState migration: #$versionNumber completed")
-    }
-  }
-
   /**
    * implement this method to upgrade the application to this version. This is
    * run in the same db transaction that commits the version number to the

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
@@ -7,7 +7,7 @@
 package com.namely.chiefofstate.migration.versions.v1
 
 import com.namely.chiefofstate.migration.{DbUtil, Migrator, StringImprovements, Version}
-import com.namely.chiefofstate.migration.versions.v1.V1.{createTable, insertInto, tempTable, OffsetRow}
+import com.namely.chiefofstate.migration.versions.v1.V1.{createTable, insertInto, offsetTableName, tempTable, OffsetRow}
 import org.slf4j.{Logger, LoggerFactory}
 import slick.basic.DatabaseConfig
 import slick.dbio.DBIO
@@ -28,7 +28,7 @@ import scala.util.Try
 case class V1(
   journalJdbcConfig: DatabaseConfig[JdbcProfile],
   projectionJdbcConfig: DatabaseConfig[JdbcProfile],
-  offsetStoreTable: String
+  priorOffsetStoreTable: String
 ) extends Version {
 
   final val log: Logger = LoggerFactory.getLogger(getClass)
@@ -74,17 +74,15 @@ case class V1(
    */
   override def upgrade(): DBIO[Unit] = {
     // get the correct table name
-    val table: String = transformTableName()
+    val oldTable: String = transformTableName()
     log.info(s"finalizing ChiefOfState migration: #$versionNumber")
     DBIO.seq(
       // dropping the old table in the new projection connection
-      sqlu"""DROP TABLE IF EXISTS #$table""",
+      sqlu"""DROP TABLE IF EXISTS #$oldTable CASCADE""",
       // renaming the temporary table in the new projection connection
-      sqlu"""ALTER TABLE IF EXISTS #$tempTable RENAME TO #$table""",
-      // dropping the temporary table index
-      sqlu"""DROP INDEX IF EXISTS #${tempTable}_index""",
+      sqlu"""ALTER TABLE #$tempTable RENAME TO #$offsetTableName""",
       // creating the required index on the renamed table
-      sqlu"""CREATE INDEX IF NOT EXISTS projection_name_index ON #$table (projection_name)"""
+      sqlu"""CREATE INDEX #${offsetTableName}_projection_name_index ON #$offsetTableName (projection_name)"""
     )
   }
 
@@ -104,6 +102,20 @@ case class V1(
   private def migrate(): Int = {
     // let us fetch the records
     val data: Seq[OffsetRow] = fetchOffsetRows()
+
+    log.info(s"num records migrating to $tempTable: ${data.size}")
+
+    // ensure there are no duplicates per key in the query resultset
+    data
+      .groupBy(row => (row.projectionName, row.projectionKey))
+      .map({ case (k, records) => (k, records.size) })
+      .foreach({
+        case ((projectionName, projectionKey), recordCount) => {
+          require(recordCount == 1,
+                  s"too many records for key, name=$projectionName, key=$projectionKey, count=$recordCount"
+          )
+        }
+      })
 
     // let us insert the data into the temporary table
     insertInto(tempTable, journalJdbcConfig, data)
@@ -137,14 +149,16 @@ case class V1(
    * can be used sql statement.
    */
   private def transformTableName(): String = {
-    if (offsetStoreTable.isUpper) offsetStoreTable.quote
-    else offsetStoreTable
+    if (priorOffsetStoreTable.isUpper) priorOffsetStoreTable.quote
+    else priorOffsetStoreTable
   }
 }
 
 object V1 {
   // offset store temporary table name
   private[v1] val tempTable: String = "v1_offset_store_temp"
+  // offset store final table name
+  private[v1] val offsetTableName: String = "read_side_offsets"
 
   /**
    * creates the temporary offset store table in the write side database
@@ -152,9 +166,8 @@ object V1 {
    * @param journalJdbcConfig the database config
    */
   private[v1] def createTable(journalJdbcConfig: DatabaseConfig[JdbcProfile]): Unit = {
-    val tableCreationStmt: SqlAction[Int, NoStream, Effect] =
-      sqlu"""
-        CREATE TABLE IF NOT EXISTS #$tempTable(
+    val stmt = sqlu"""
+        CREATE TABLE #$tempTable(
           projection_name VARCHAR(255) NOT NULL,
           projection_key VARCHAR(255) NOT NULL,
           current_offset VARCHAR(255) NOT NULL,
@@ -162,20 +175,9 @@ object V1 {
           mergeable BOOLEAN NOT NULL,
           last_updated BIGINT NOT NULL,
           PRIMARY KEY(projection_name, projection_key)
-        )"""
+        )""".withPinnedSession.transactionally
 
-    val indexCreationStmt: SqlAction[Int, NoStream, Effect] =
-      sqlu"""CREATE INDEX IF NOT EXISTS #${tempTable}_index ON #$tempTable (projection_name)"""
-
-    val ddlSeq: DBIOAction[Unit, NoStream, PostgresProfile.api.Effect with Effect.Transactional] = DBIO
-      .seq(
-        tableCreationStmt,
-        indexCreationStmt
-      )
-      .withPinnedSession
-      .transactionally
-
-    Await.result(journalJdbcConfig.db.run(ddlSeq), Duration.Inf)
+    Await.result(journalJdbcConfig.db.run(stmt), Duration.Inf)
   }
 
   /**

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
@@ -93,18 +93,6 @@ case class V1(
 
     log.info(s"num records migrating to $tempTable: ${data.size}")
 
-    // ensure there are no duplicates per key in the query resultset
-    data
-      .groupBy(row => (row.projectionName, row.projectionKey))
-      .map({ case (k, records) => (k, records.size) })
-      .foreach({
-        case ((projectionName, projectionKey), recordCount) => {
-          require(recordCount == 1,
-                  s"too many records for key, name=$projectionName, key=$projectionKey, count=$recordCount"
-          )
-        }
-      })
-
     // let us insert the data into the temporary table
     insertInto(tempTable, journalJdbcConfig, data)
   }

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/helper/TestConfig.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/helper/TestConfig.scala
@@ -30,12 +30,7 @@ object TestConfig {
     ConfigFactory.parseString(cfgString)
   }
 
-  def getProjectionConfig(url: String,
-                          user: String,
-                          password: String,
-                          tableName: String,
-                          useLowerCase: Boolean
-  ): Config = {
+  def getProjectionConfig(url: String, user: String, password: String, useLowerCase: Boolean): Config = {
     val cfgString: String = s"""
       akka.projection.slick {
         profile = "slick.jdbc.PostgresProfile$$"
@@ -47,7 +42,7 @@ object TestConfig {
           url = "$url"
         }
         offset-store {
-          table = $tableName
+          table = "read_side_offsets"
           use-lowercase-schema = $useLowerCase
         }
       }

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v1/V1Spec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v1/V1Spec.scala
@@ -186,34 +186,6 @@ class V1Spec extends BaseSpec with ForAllTestContainer {
       count(journalJdbcConfig) shouldBe 3
     }
   }
-  ".afterUpgrade" should {
-    "drop the table on the old connection" in {
-      // given an instance of V1 version
-      val v1: V1 = V1(journalJdbcConfig, projectionJdbcConfig, "read_side_offsets")
-
-      // create the actual offset store table
-      // create the old read side offset store
-      noException shouldBe thrownBy(createOldOffsetTable(projectionJdbcConfig))
-
-      v1.afterUpgrade().isSuccess shouldBe true
-
-      DbUtil.tableExists(projectionJdbcConfig, "read_side_offsets") shouldBe false
-
-    }
-    "do nothing if on the new connection" in {
-      // given an instance of V1 version
-      val v1: V1 = V1(journalJdbcConfig, projectionJdbcConfig, "read_side_offsets")
-
-      // create cos migrations table
-      noException shouldBe thrownBy(createMigrationsTable(projectionJdbcConfig))
-
-      // create the actual offset store table
-      // create the old read side offset store
-      noException shouldBe thrownBy(createOldOffsetTable(projectionJdbcConfig))
-
-      v1.afterUpgrade().isSuccess shouldBe true
-    }
-  }
   ".upgrade" should {
     "drop the old table and index" in {
       // given an instance of V1 version

--- a/code/service/src/main/resources/application.conf
+++ b/code/service/src/main/resources/application.conf
@@ -389,14 +389,14 @@ chiefofstate {
 		trace_propagators = "b3multi"
 		trace_propagators = ${?COS_TRACE_PROPAGATORS}
 	}
-}
 
-cos-migration {
-	v1 {
-		# this was an old "v0" feature that allowed setting the akka projection
-		# offset store table name. this is required here to allow migration
-		# to v1
-		offset-table-old-name = "AKKA_PROJECTION_OFFSET_STORE"
-		offset-table-old-name = ${?COS_READ_SIDE_OFFSET_STORE_TABLE}
+	migration {
+		v1 {
+			# this was an old "v0" feature that allowed setting the akka projection
+			# offset store table name. this is required here to allow migration
+			# to v1
+			offset-table-old-name = "AKKA_PROJECTION_OFFSET_STORE"
+			offset-table-old-name = ${?COS_READ_SIDE_OFFSET_STORE_TABLE}
+		}
 	}
 }

--- a/code/service/src/main/resources/application.conf
+++ b/code/service/src/main/resources/application.conf
@@ -36,18 +36,18 @@ akka {
 			"scalapb.GeneratedMessage" = proto
 			"com.namely.chiefofstate.AggregateCommand" = cmdSerializer
 		}
-		
+
 		# This will stop the guardian actor in case of any exception which will therefore
 		# shutdown the whole actor system
 		guardian-supervisor-strategy = "akka.actor.StoppingSupervisorStrategy"
 	}
-	
+
 	persistence {
 		# akka persistence jdbc
 		journal.plugin = "jdbc-journal"
 		snapshot-store.plugin = "jdbc-snapshot-store"
 	}
-	
+
 	cluster {
 		sharding {
 			# Number of shards used by the default HashCodeMessageExtractor
@@ -93,14 +93,14 @@ akka {
 		}
 		shutdown-after-unsuccessful-join-seed-nodes = 20s
 	}
-	
+
 	coordinated-shutdown {
 		terminate-actor-system = on
 		exit-jvm = on
 		run-by-actor-system-terminate = on
 		run-by-jvm-shutdown-hook = on
 	}
-	
+
 	projection {
 		slick {
 			# The Slick profile to use
@@ -114,33 +114,33 @@ akka {
 				# default to the journal jdbc settings, but allow optional overrides
 				user = ${jdbc-default.user}
 				user = ${?COS_READ_SIDE_OFFSET_DB_USER}
-				
+
 				password = ${jdbc-default.password}
 				password = ${?COS_READ_SIDE_OFFSET_DB_PASSWORD}
-				
+
 				serverName = ${jdbc-default.host}
 				serverName = ${?COS_READ_SIDE_OFFSET_DB_HOST}
-				
+
 				portNumber = ${jdbc-default.port}
 				portNumber = ${?COS_READ_SIDE_OFFSET_DB_PORT}
-				
+
 				databaseName = ${jdbc-default.database}
 				databaseName = ${?COS_READ_SIDE_OFFSET_DB}
-				
+
 				url = "jdbc:postgresql://"${akka.projection.slick.db.serverName}":"${akka.projection.slick.db.portNumber}"/"${akka.projection.slick.db.databaseName}"?currentSchema="${akka.projection.slick.offset-store.schema}
-				
+
 				connectionPool = "HikariCP"
 				keepAliveConnection = true
 			}
-			
+
 			offset-store {
 				# set this to your database schema if applicable, empty by default
 				schema = ${jdbc-default.schema}
 				schema = ${?COS_READ_SIDE_OFFSET_DB_SCHEMA}
-				
+
 				# the database table name for the offset store
 				table = "read_side_offsets"
-				table = ${?COS_READ_SIDE_OFFSET_STORE_TABLE}
+
 				# check migration note https://github.com/akka/akka-projection/releases/tag/v1.1.0
 				# set this to true this when migration tool is done
 				use-lowercase-schema = true
@@ -154,12 +154,12 @@ akka {
 			min-backoff = 3s
 			max-backoff = 30s
 			random-factor = 0.2
-			
+
 			# -1 will not cap the amount of restarts
 			# 0 will disable restarts
 			max-restarts = -1
 		}
-		
+
 		# The strategy to use to recover from unhandled exceptions without causing the projection to fail
 		recovery-strategy {
 			# fail - If the first attempt to invoke the handler fails it will immediately give up and fail the stream.
@@ -172,11 +172,11 @@ akka {
 			# same envelope this number of `retries` with the `delay` between each attempt. It will give up,
 			# discard the element and continue with next if all attempts fail.
 			strategy = fail
-			
+
 			# The number of times to retry handler function
 			# This is only applicable to `retry-and-fail` and `retry-and-skip` recovery strategies
 			retries = 5
-			
+
 			# The delay between retry attempts
 			# Only applicable to `retry-and-fail` and `retry-and-skip` recovery strategies
 			retry-delay = 1 s
@@ -213,13 +213,13 @@ write-side-slick {
 		numThreads = 20
 		maxConnections = 20
 		minConnections = 5
-		
+
 		# This property controls the maximum amount of time that a connection is allowed to sit idle in the pool.
 		# Whether a connection is retired as idle or not is subject to a maximum variation of +30 seconds, and average variation
 		# of +15 seconds. A connection will never be retired as idle before this timeout. A value of 0 means that idle connections
 		# are never removed from the pool. Default: 600000 (10 minutes)
 		idleTimeout = 600000
-		
+
 		# This property controls the maximum lifetime of a connection in the pool. When a connection reaches this timeout
 		# it will be retired from the pool, subject to a maximum variation of +30 seconds. An in-use connection will never be retired,
 		# only when it is closed will it then be removed. We strongly recommend setting this value, and it should be at least 30 seconds
@@ -237,14 +237,14 @@ jdbc-journal {
 			tableName = "journal"
 			schemaName = ${jdbc-default.schema}
 		}
-		
+
 		# this is the new going forward
 		# ref: https://github.com/akka/akka-persistence-jdbc/blob/v5.0.0/core/src/main/resources/reference.conf
 		event_journal {
 			tableName = "event_journal"
 			schemaName = ${jdbc-default.schema}
 		}
-		
+
 		event_tag {
 			tableName = "event_tag"
 			schemaName = ${jdbc-default.schema}
@@ -277,7 +277,7 @@ jdbc-snapshot-store {
 			tableName = "snapshot"
 			schemaName = ${jdbc-default.schema}
 		}
-		
+
 		# This is the new configuration going forward
 		snapshot {
 			tableName = "state_snapshot"
@@ -292,13 +292,13 @@ chiefofstate {
 	# the service name
 	service-name = "chiefofstate"
 	service-name = ${?COS_SERVICE_NAME}
-	
+
 	# Ask timeout is required to
 	# send commands to the aggregate root and receive response
 	# the unit value is in second
 	ask-timeout = 5
 	ask-timeout = ${?COS_COMMAND_HANDLER_TIMEOUT}
-	
+
 	snapshot-criteria {
 		# Snapshots are not saved and deleted automatically, events are not deleted
 		disable-snapshot = false
@@ -315,7 +315,7 @@ chiefofstate {
 		delete-events-on-snapshot = false
 		delete-events-on-snapshot = ${?COS_JOURNAL_LOGICAL_DELETION}
 	}
-	
+
 	events {
 		# the events tag name prefix. it is advised to leave this setting alone.
 		# DO NOT CHANGE THIS SETTING ONCE THERE ARE EVENTS UNLESS YOU ARE
@@ -323,7 +323,7 @@ chiefofstate {
 		tagname: "chiefofstate"
 		tagname: ${?COS_EVENTS_TAG_NAME}
 	}
-	
+
 	grpc {
 		client {
 			# the deadline timeout, a duration of time after which the RPC times out.
@@ -340,7 +340,7 @@ chiefofstate {
 			address = ${?COS_ADDRESS}
 		}
 	}
-	
+
 	write-side {
 		# Write handler gRPC host
 		host = ""
@@ -367,26 +367,36 @@ chiefofstate {
 		propagated-headers = ""
 		propagated-headers = ${?COS_WRITE_SIDE_PROPAGATED_HEADERS}
 	}
-	
+
 	read-side {
 		# set this value to true whenever a readSide config is set
 		enabled = false
 		enabled = ${?COS_READ_SIDE_ENABLED}
 	}
-	
+
 	plugin-settings {
 		enabled-plugins = "com.namely.chiefofstate.plugin.PersistedHeaders"
 		enabled-plugins = ${?COS_ENABLED_PLUGINS}
 	}
-	
+
 	telemetry {
 		namespace = ""
 		namespace = ${?COS_TELEMETRY_NAMESPACE}
-		
+
 		otlp_endpoint = ""
 		otlp_endpoint = ${?COS_TELEMETRY_COLLECTOR_ENDPOINT}
-		
+
 		trace_propagators = "b3multi"
 		trace_propagators = ${?COS_TRACE_PROPAGATORS}
+	}
+}
+
+cos-migration {
+	v1 {
+		# this was an old "v0" feature that allowed setting the akka projection
+		# offset store table name. this is required here to allow migration
+		# to v1
+		offset-table-old-name = "AKKA_PROJECTION_OFFSET_STORE"
+		offset-table-old-name = ${?COS_READ_SIDE_OFFSET_STORE_TABLE}
 	}
 }

--- a/code/service/src/main/scala/com/namely/chiefofstate/StartNodeBehaviour.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/StartNodeBehaviour.scala
@@ -79,7 +79,7 @@ object StartNodeBehaviour {
         val v1: V1 = V1(
           journalJdbcConfig,
           projectionJdbcConfig,
-          config.getString("cos-migration.v1.offset-table-old-name")
+          config.getString("chiefofstate.migration.v1.offset-table-old-name")
         )
         val v2: V2 = V2(journalJdbcConfig, projectionJdbcConfig)(context.system)
 

--- a/code/service/src/main/scala/com/namely/chiefofstate/StartNodeBehaviour.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/StartNodeBehaviour.scala
@@ -76,8 +76,11 @@ object StartNodeBehaviour {
           JdbcConfig.projectionConfig(config)
 
         // TODO: think about a smarter constructor for the migrator
-        val offsetStoreTableName: String = config.getString("akka.projection.slick.offset-store.table")
-        val v1: V1 = V1(journalJdbcConfig, projectionJdbcConfig, offsetStoreTableName)
+        val v1: V1 = V1(
+          journalJdbcConfig,
+          projectionJdbcConfig,
+          config.getString("cos-migration.v1.offset-table-old-name")
+        )
         val v2: V2 = V2(journalJdbcConfig, projectionJdbcConfig)(context.system)
 
         new Migrator(journalJdbcConfig)


### PR DESCRIPTION
Changes:
- requires read side table name `read_side_offsets`
- moves old read side table to `migrations.v1` settings
- only create final projections index in `.upgrade`
- remove `if exists` for create/drop statements where it shouldn't fail
- fix tests for `.upgrade` to ensure it creates tables
- remove `V1.afterUpgrade` (too scary)