### PR TITLE
Direct journal transforms in v2 migration

### DIFF
--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v2/MigrateJournal.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v2/MigrateJournal.scala
@@ -88,8 +88,8 @@ case class MigrateJournal(system: ActorSystem[_],
       .fromPublisher(journaldb.stream(query))
       // transform to new types and extract tags
       .map(journalRow => {
-        upgradeJournalRow(journalRow) match {
-          case Success(newRow) => (newRow, upgradeTags(journalRow.tags))
+        MigrateJournal.upgradeJournalRow(journalRow) match {
+          case Success(newRow) => (newRow, MigrateJournal.upgradeTags(journalRow.tags))
           case Failure(e)      => throw e
         }
       })
@@ -162,6 +162,9 @@ case class MigrateJournal(system: ActorSystem[_],
 
     journalInsert.flatMap(_ => tagInserts.asInstanceOf[DBIO[Unit]])
   }
+}
+
+object MigrateJournal {
 
   /**
    * convert the old akka journal row to the new one, assuming proto serialization

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/MigrateJournalSpec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/MigrateJournalSpec.scala
@@ -347,4 +347,12 @@ class MigrateJournalSpec extends BaseSpec with ForAllTestContainer {
       oldOrdNrAndSeqNr.equals(newOrdNrAndSeqNr) shouldBe true
     }
   }
+  ".upgradeJournalRow" should {
+    "transform an old row to a new row" in {
+      // TODO
+    }
+    "fail to transform a bad old row" in {
+      // TODO
+    }
+  }
 }


### PR DESCRIPTION
This PR moves to directly deserializing the old journal rows and manually constructing the new rows. We can take this simpler path as we know that akka proto serialization was used before and after, so we don't need the complexity introduced by the general akka serde.