### PR TITLE
restore from journal, no snapshots

### DIFF
--- a/code/service/src/main/resources/application.conf
+++ b/code/service/src/main/resources/application.conf
@@ -45,7 +45,7 @@ akka {
 	persistence {
 		# akka persistence jdbc
 		journal.plugin = "jdbc-journal"
-		snapshot-store.plugin = "jdbc-snapshot-store"
+		snapshot-store.plugin = "cos-snapshot-store"
 	}
 
 	cluster {
@@ -269,6 +269,14 @@ jdbc-read-journal {
 		event_tag = ${jdbc-journal.tables.event_tag}
 	}
 	slick = ${write-side-slick}
+}
+
+cos-snapshot-store {
+	# Class name of the plugin.
+	class = "com.namely.chiefofstate.CosSnapshotStore"
+	# Dispatcher for the plugin actor
+	# this is the default.
+	plugin-dispatcher = "akka.persistence.dispatchers.default-plugin-dispatcher"
 }
 
 # the akka-persistence-snapshot-store in use

--- a/code/service/src/main/scala/com/namely/chiefofstate/AggregateRoot.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/AggregateRoot.scala
@@ -29,6 +29,7 @@ import org.slf4j.{Logger, LoggerFactory}
 import java.time.Instant
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success, Try}
+import akka.persistence.typed.SnapshotSelectionCriteria
 
 /**
  *  This is an event sourced actor.
@@ -72,6 +73,7 @@ object AggregateRoot {
           .withTagger(_ => Set(tags(cosConfig.eventsConfig)(shardIndex)))
           .withRetention(setSnapshotRetentionCriteria(cosConfig.snapshotConfig))
           .onPersistFailure(SupervisorStrategy.restartWithBackoff(200.millis, 5.seconds, 0.1))
+          .withRecovery(Recovery.withSnapshotSelectionCriteria(SnapshotSelectionCriteria.latest))
       }
     }
   }

--- a/code/service/src/main/scala/com/namely/chiefofstate/CosSnapshotStore.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/CosSnapshotStore.scala
@@ -1,7 +1,13 @@
+/*
+ * Copyright 2020 Namely Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 package com.namely.chiefofstate
 
 import akka.persistence.snapshot.SnapshotStore
-import akka.persistence.{SelectedSnapshot, SnapshotSelectionCriteria, SnapshotMetadata}
+import akka.persistence.{SelectedSnapshot, SnapshotMetadata, SnapshotSelectionCriteria}
 import scala.concurrent.Future
 import org.slf4j.{Logger, LoggerFactory}
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
@@ -15,6 +21,12 @@ import akka.persistence.query.EventEnvelope
 import akka.NotUsed
 import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
 
+/**
+ * Custom akka persistence snapshot store for restoring from the akka jdbc
+ * journal directly. This eliminates the need for a separate snapshot table.
+ *
+ * @param config typesafe config for the snapshot
+ */
 class CosSnapshotStore(config: Config) extends SnapshotStore {
 
   implicit val ec: ExecutionContext = context.dispatcher
@@ -23,45 +35,77 @@ class CosSnapshotStore(config: Config) extends SnapshotStore {
   private[chiefofstate] val readJournal: JdbcReadJournal = PersistenceQuery(system)
     .readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier)
 
-  override def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
+  /**
+   * implements loadAsync for akka persistence snapshots to read from the
+   * jdbc journal and return an empty "snapshot" pointing to the highest
+   * persisted sequence number. This works since COS persists each resulting
+   * state in the journal.
+   *
+   * @param persistenceId persistence ID to restore
+   * @param criteria snapshot criteria to restore
+   * @return optional selected snapshot
+   */
+  override def loadAsync(persistenceId: String,
+                         criteria: SnapshotSelectionCriteria
+  ): Future[Option[SelectedSnapshot]] = {
     logger.debug(s"loadAsync, persistenceId=$persistenceId, criteria=$criteria")
 
     // get the events for this entity
     val source: Source[EventEnvelope, NotUsed] = readJournal
-      .currentEventsByPersistenceId(persistenceId, Long.MinValue, Long.MaxValue)
+      .currentEventsByPersistenceId(persistenceId, criteria.minSequenceNr, criteria.maxSequenceNr)
 
     val maxEnvelopeFuture: Future[Option[EventEnvelope]] = source
-    // fold to the max sequence number
-    .runFold[Option[EventEnvelope]](None)((maxEnvelope: Option[EventEnvelope], nextEnvelope: EventEnvelope) => {
-      maxEnvelope.map(prior => {
-        if(prior.sequenceNr < nextEnvelope.sequenceNr) prior else nextEnvelope
+      // fold to the max sequence number
+      .runFold[Option[EventEnvelope]](None)((maxEnvelope: Option[EventEnvelope], nextEnvelope: EventEnvelope) => {
+        maxEnvelope.map(prior => {
+          if (prior.sequenceNr < nextEnvelope.sequenceNr) prior else nextEnvelope
+        })
       })
-    })
 
     maxEnvelopeFuture
-    .map(_.map((maxEnvelope: EventEnvelope) => {
-      // FIXME, make a debug log
-      logger.info(s"restoring, persistenceId=${maxEnvelope.persistenceId}, sequenceNo=${maxEnvelope.persistenceId}")
+      .map(_.map((maxEnvelope: EventEnvelope) => {
+        // FIXME, make a debug log
+        logger.info(s"restoring, persistenceId=${maxEnvelope.persistenceId}, sequenceNo=${maxEnvelope.persistenceId}")
 
-      SelectedSnapshot(
-        metadata = SnapshotMetadata(
-          persistenceId = maxEnvelope.persistenceId,
-          sequenceNr = maxEnvelope.sequenceNr,
-          timestamp = maxEnvelope.timestamp
-        ),
-        StateWrapper.defaultInstance
-      )
-    }))
+        SelectedSnapshot(
+          metadata = SnapshotMetadata(
+            persistenceId = maxEnvelope.persistenceId,
+            sequenceNr = maxEnvelope.sequenceNr,
+            timestamp = maxEnvelope.timestamp
+          ),
+          StateWrapper.defaultInstance
+        )
+      }))
   }
 
+  /**
+   * dummy implementation of the async save of snapshots, which does nothing
+   *
+   * @param metadata ignored
+   * @param snapshot ignored
+   * @return successful future
+   */
   override def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] = {
     Future.unit
   }
 
+  /**
+   * dummy deletion method, since there are no snapshots in the db
+   *
+   * @param metadata ignored
+   * @return successful future
+   */
   override def deleteAsync(metadata: SnapshotMetadata): Future[Unit] = {
     Future.unit
   }
 
+  /**
+   * dummy implementation of deletion, since there are no snapshots in the db
+   *
+   * @param persistenceId ignored
+   * @param criteria ignored
+   * @return successful future
+   */
   override def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] = {
     Future.unit
   }

--- a/code/service/src/main/scala/com/namely/chiefofstate/CosSnapshotStore.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/CosSnapshotStore.scala
@@ -58,7 +58,7 @@ class CosSnapshotStore(config: Config) extends SnapshotStore {
       // fold to the max sequence number
       .runFold[Option[EventEnvelope]](None)((maxEnvelope: Option[EventEnvelope], nextEnvelope: EventEnvelope) => {
         maxEnvelope.map(prior => {
-          if (prior.sequenceNr < nextEnvelope.sequenceNr) prior else nextEnvelope
+          if (prior.sequenceNr < nextEnvelope.sequenceNr) nextEnvelope else prior
         })
       })
 

--- a/code/service/src/main/scala/com/namely/chiefofstate/CosSnapshotStore.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/CosSnapshotStore.scala
@@ -1,0 +1,73 @@
+package com.namely.chiefofstate
+
+import akka.persistence.snapshot.SnapshotStore
+import akka.persistence.{SelectedSnapshot, SnapshotSelectionCriteria, SnapshotMetadata}
+import scala.concurrent.Future
+import org.slf4j.{Logger, LoggerFactory}
+import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
+import akka.persistence.query.PersistenceQuery
+import com.typesafe.config.Config
+import scala.concurrent.ExecutionContext
+import akka.actor.ActorSystem
+import CosSnapshotStore.logger
+import akka.stream.scaladsl.Source
+import akka.persistence.query.EventEnvelope
+import akka.NotUsed
+import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
+
+class CosSnapshotStore(config: Config) extends SnapshotStore {
+
+  implicit val ec: ExecutionContext = context.dispatcher
+  implicit val system: ActorSystem = context.system
+
+  private[chiefofstate] val readJournal: JdbcReadJournal = PersistenceQuery(system)
+    .readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier)
+
+  override def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
+    logger.debug(s"loadAsync, persistenceId=$persistenceId, criteria=$criteria")
+
+    // get the events for this entity
+    val source: Source[EventEnvelope, NotUsed] = readJournal
+      .currentEventsByPersistenceId(persistenceId, Long.MinValue, Long.MaxValue)
+
+    val maxEnvelopeFuture: Future[Option[EventEnvelope]] = source
+    // fold to the max sequence number
+    .runFold[Option[EventEnvelope]](None)((maxEnvelope: Option[EventEnvelope], nextEnvelope: EventEnvelope) => {
+      maxEnvelope.map(prior => {
+        if(prior.sequenceNr < nextEnvelope.sequenceNr) prior else nextEnvelope
+      })
+    })
+
+    maxEnvelopeFuture
+    .map(_.map((maxEnvelope: EventEnvelope) => {
+      // FIXME, make a debug log
+      logger.info(s"restoring, persistenceId=${maxEnvelope.persistenceId}, sequenceNo=${maxEnvelope.persistenceId}")
+
+      SelectedSnapshot(
+        metadata = SnapshotMetadata(
+          persistenceId = maxEnvelope.persistenceId,
+          sequenceNr = maxEnvelope.sequenceNr,
+          timestamp = maxEnvelope.timestamp
+        ),
+        StateWrapper.defaultInstance
+      )
+    }))
+  }
+
+  override def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] = {
+    Future.unit
+  }
+
+  override def deleteAsync(metadata: SnapshotMetadata): Future[Unit] = {
+    Future.unit
+  }
+
+  override def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] = {
+    Future.unit
+  }
+
+}
+
+object CosSnapshotStore {
+  private lazy val logger: Logger = LoggerFactory.getLogger(this.getClass().getName())
+}

--- a/code/service/src/main/scala/com/namely/chiefofstate/CosSnapshotStore.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/CosSnapshotStore.scala
@@ -64,8 +64,7 @@ class CosSnapshotStore(config: Config) extends SnapshotStore {
 
     maxEnvelopeFuture
       .map(_.map((maxEnvelope: EventEnvelope) => {
-        // FIXME, make a debug log
-        logger.info(s"restoring, persistenceId=${maxEnvelope.persistenceId}, sequenceNo=${maxEnvelope.persistenceId}")
+        logger.debug(s"restoring, persistenceId=${maxEnvelope.persistenceId}, sequenceNo=${maxEnvelope.persistenceId}")
 
         SelectedSnapshot(
           metadata = SnapshotMetadata(


### PR DESCRIPTION
This implements a simple, custom akka persistence snapshot plugin to restore actors from the journal.

Changes:
- [x] make actors restore from journal without snapshot table
- [ ] remove snapshot table in new migrations
- [ ] make sure old migrations work (prob disable the old migrations config)