### PR TITLE
Issue-232: Propagate gRPC error details from command handler

### DIFF
--- a/code/service/src/main/scala/com/namely/chiefofstate/AggregateRoot.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/AggregateRoot.scala
@@ -230,9 +230,11 @@ object AggregateRoot {
         persistEventAndReply(event, newState, eventMeta, replyTo)
 
       case Failure(e: StatusException) =>
+        // record the exception on the current span
         Span.current().recordException(e).setStatus(StatusCode.ERROR)
+        // reply with the error status
         Effect.reply(replyTo)(
-          CommandReply().withError(toRpcStatus(e.getStatus))
+          CommandReply().withError(toRpcStatus(e.getStatus(), e.getTrailers()))
         )
 
       case x =>

--- a/code/service/src/main/scala/com/namely/chiefofstate/GrpcServiceImpl.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/GrpcServiceImpl.scala
@@ -109,9 +109,10 @@ object GrpcServiceImpl {
    * @param metadata the gRPC metadata
    * @return the RemoteCommand object
    */
-  private[chiefofstate] def getRemoteCommand(writeSideConfig: WriteSideConfig,
-                                             processCommandRequest: ProcessCommandRequest,
-                                             metadata: Metadata
+  private[chiefofstate] def getRemoteCommand(
+    writeSideConfig: WriteSideConfig,
+    processCommandRequest: ProcessCommandRequest,
+    metadata: Metadata
   ): RemoteCommand = {
     // get the headers to forward
     val propagatedHeaders: Seq[RemoteCommand.Header] = Util

--- a/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Namely Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.namely.chiefofstate
+
+import com.namely.chiefofstate.helper.BaseSpec
+import com.namely.protobuf.chiefofstate.v1.internal.CommandReply
+import io.grpc.StatusException
+import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
+import com.namely.protobuf.chiefofstate.v1.common.MetaData
+import com.google.protobuf.any
+import scala.util.Success
+import com.google.rpc.error_details.BadRequest
+import io.grpc.protobuf.StatusProto
+import com.google.rpc.status.Status
+
+class GrpcServiceImplSpec extends BaseSpec {
+  ".handleCommandReply" should {
+    "pass through success" in {
+      val stateWrapper = StateWrapper()
+        .withMeta(MetaData().withRevisionNumber(2))
+
+      val commandReply: CommandReply = CommandReply()
+        .withState(stateWrapper)
+
+      val actual = GrpcServiceImpl.handleCommandReply(commandReply)
+
+      actual shouldBe Success(stateWrapper)
+    }
+    "preserve error details" in {
+      // define a field violation
+      val errField = BadRequest
+        .FieldViolation()
+        .withField("some_field")
+        .withDescription("oh no")
+
+      // create the bad request detail
+      val errDetail: BadRequest = BadRequest()
+        .addFieldViolations(errField)
+
+      // create an error status with this detail
+      val expectedStatus: com.google.rpc.status.Status =
+        com.google.rpc.status
+          .Status()
+          .withCode(com.google.rpc.code.Code.INVALID_ARGUMENT.value)
+          .withMessage("some error message")
+          .addDetails(com.google.protobuf.any.Any.pack(errDetail))
+
+      val commandReply: CommandReply = CommandReply()
+        .withError(expectedStatus)
+
+      val statusException: StatusException = intercept[StatusException] {
+        GrpcServiceImpl.handleCommandReply(commandReply).get
+      }
+
+      val javaStatus = StatusProto.fromStatusAndTrailers(
+        statusException.getStatus(),
+        statusException.getTrailers()
+      )
+
+      val actual = Status.parseFrom(javaStatus.toByteArray())
+
+      actual shouldBe expectedStatus
+
+    }
+    "handle defailt case" in {
+      val commandReply: CommandReply = CommandReply()
+        .withReply(CommandReply.Reply.Empty)
+
+      assertThrows[StatusException] {
+        GrpcServiceImpl.handleCommandReply(commandReply).get
+      }
+    }
+  }
+}

--- a/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
@@ -16,8 +16,66 @@ import scala.util.Success
 import com.google.rpc.error_details.BadRequest
 import io.grpc.protobuf.StatusProto
 import com.google.rpc.status.Status
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import io.grpc.Metadata
+import com.namely.chiefofstate.config.WriteSideConfig
+import com.namely.protobuf.chiefofstate.v1.service.ProcessCommandRequest
+import com.google.protobuf.wrappers.StringValue
+import com.namely.protobuf.chiefofstate.v1.internal.RemoteCommand
 
 class GrpcServiceImplSpec extends BaseSpec {
+  ".getRemoteCommand" should {
+    "invoke the Util helper" in {
+
+      val key: String = "some-header"
+      val value: String = "some value"
+
+      val config: WriteSideConfig = WriteSideConfig(
+        host = "x",
+        port = 0,
+        useTls = false,
+        enableProtoValidation = false,
+        eventsProtos = Seq.empty[String],
+        statesProtos = Seq.empty[String],
+        propagatedHeaders = Seq(key)
+      )
+
+      val metadata: Metadata = new Metadata()
+      val stringHeaderKey: Metadata.Key[String] = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER)
+      metadata.put(stringHeaderKey, value)
+
+      val command = ProcessCommandRequest()
+        .withCommand(any.Any.pack(StringValue("x")))
+
+      val actual = GrpcServiceImpl.getRemoteCommand(config, command, metadata)
+
+      val expected = RemoteCommand()
+        .withCommand(command.getCommand)
+        .addHeaders(
+          RemoteCommand
+            .Header()
+            .withKey(key)
+            .withStringValue(value)
+        )
+
+      actual shouldBe expected
+    }
+  }
+
+  ".requireEntityId" should {
+    "fail if entity missing" in {
+      assertThrows[StatusException] {
+        Await.result(GrpcServiceImpl.requireEntityId(""), Duration.Inf)
+      }
+    }
+    "pass if entity provided" in {
+      noException shouldBe thrownBy {
+        Await.result(GrpcServiceImpl.requireEntityId("x"), Duration.Inf)
+      }
+    }
+  }
+
   ".handleCommandReply" should {
     "pass through success" in {
       val stateWrapper = StateWrapper()

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -66,9 +66,7 @@ object Common extends AutoPlugin {
       logBuffered in Test := false,
       coverageExcludedPackages := "<empty>;com.namely.protobuf.*;" +
         "com.namely.chiefofstate.StartNodeBehaviour;" +
-        "com.namely.chiefofstate.GrpcHeadersInterceptor;" +
-        "com.namely.chiefofstate.StartNode;" +
-        "com.namely.chiefofstate.GrpcServiceImpl;",
+        "com.namely.chiefofstate.StartNode;",
       fork in Test := true
     )
 }


### PR DESCRIPTION
This PR makes COS support the [rich error model](https://grpc.io/docs/guides/error/#richer-error-model) for gRPC, and correctly passes through any provided details for write-handler error statuses.

See integration test PR in the python sample app:
https://github.com/namely/cos-python-sample/pull/19

resolves #232 