### PR TITLE
Improve migrator logging

### DIFF
--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/Migrator.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/Migrator.scala
@@ -16,8 +16,7 @@ import java.time.Instant
 import scala.collection.mutable
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
-import scala.util.Try
-import scala.util.Success
+import scala.util.{Try, Success}
 
 class Migrator(val journalDbConfig: DatabaseConfig[JdbcProfile]) {
   val logger: Logger = Migrator.logger


### PR DESCRIPTION
Makes the migrator.run logging less confusing (for use in the migration singleton #280)

@Tochemey this should allow you to just call `migrator.run()` and not check if there are versions.