### PR TITLE
add allowed classes for v2 proto migration

### DIFF
--- a/code/service/src/main/resources/application.conf
+++ b/code/service/src/main/resources/application.conf
@@ -24,6 +24,13 @@ jdbc-default {
 }
 
 akka {
+	# this allows our application to use the old akka proto
+	# serializer to read the journal pre-migration
+	serialization.protobuf.allowed-classes = [
+		"com.namely.protobuf.chiefofstate.v1.persistence.EventWrapper",
+		"com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper"
+	]
+
 	loglevel = ERROR
 	loglevel = ${?LOG_LEVEL}
 	log-dead-letters-during-shutdown = on


### PR DESCRIPTION
the V2 migration needs to use the old serializer to read the prior journal. This whitelists our two proto classes accordingly.

When upgrading from COS v0.7, the V2 Migration errors with:
> Can't deserialize object of type [com.namely.protobuf.chiefofstate.v1.persistence.EventWrapper] in [akka.remote.serialization.ProtobufSerializer]. Only classes that are on the allow list are allowed for security reasons. Configure allowed classes with akka.actor.serialization-bindings or akka.serialization.protobuf.allowed-classes

I was able to reproduce this in the python sample app, and this PR fixes it.