### PR TITLE
Fix readside projection key

### DIFF
--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/SchemasUtil.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/SchemasUtil.scala
@@ -121,7 +121,7 @@ object SchemasUtil {
   /**
    * creates the various write-side stores and read-side offset stores
    */
-  def createJournalTables(journalJdbcConfig: DatabaseConfig[JdbcProfile]): Unit = {
+  def createStoreTables(journalJdbcConfig: DatabaseConfig[JdbcProfile]): Unit = {
     val ddlSeq = DBIO
       .seq(
         createEventJournalStmt,

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v2/V2.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v2/V2.scala
@@ -68,7 +68,7 @@ case class V2(journalJdbcConfig: DatabaseConfig[JdbcProfile], projectionJdbcConf
       SchemasUtil.dropJournalTables(journalJdbcConfig)
 
       log.info("creating new ChiefOfState journal tables")
-      SchemasUtil.createJournalTables(journalJdbcConfig)
+      SchemasUtil.createStoreTables(journalJdbcConfig)
 
       log.info("migrating ChiefOfState old journal data to the new journal table")
       journalMigrator.run()

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v3/V3.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v3/V3.scala
@@ -51,7 +51,7 @@ case class V3(
         UPDATE event_tag
         SET tag = regexp_replace(tag, '^chiefofstate', '')
       """,
-      // remove "chieofstate" prefix from tags
+      // remove "chieofstate" prefix from read_side_offsets
       sqlu"""
          UPDATE read_side_offsets
         SET projection_key = regexp_replace(projection_key, '^chiefofstate', '')

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v3/V3.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v3/V3.scala
@@ -50,6 +50,11 @@ case class V3(
       sqlu"""
         UPDATE event_tag
         SET tag = regexp_replace(tag, '^chiefofstate', '')
+      """,
+      // remove "chieofstate" prefix from tags
+      sqlu"""
+         UPDATE read_side_offsets
+        SET projection_key = regexp_replace(projection_key, '^chiefofstate', '')
       """
     )
   }

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v4/V4.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v4/V4.scala
@@ -59,7 +59,7 @@ case class V4(
    */
   override def snapshot(): DBIO[Unit] = {
     log.info(s"running snapshot for version #$versionNumber")
-    SchemasUtil.createJournalTables(journalJdbcConfig)
+    SchemasUtil.createStoreTables(journalJdbcConfig)
     DBIO.successful {}
   }
 }

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/SchemasUtilSpec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/SchemasUtilSpec.scala
@@ -68,14 +68,14 @@ class SchemasUtilSpec extends BaseSpec with ForAllTestContainer {
 
   "An instance of SchemasUtils" should {
     "create the journal tables" in {
-      SchemasUtil.createJournalTables(journalJdbcConfig) shouldBe {}
+      SchemasUtil.createStoreTables(journalJdbcConfig) shouldBe {}
       DbUtil.tableExists(journalJdbcConfig, "event_journal") shouldBe true
       DbUtil.tableExists(journalJdbcConfig, "event_tag") shouldBe true
       DbUtil.tableExists(journalJdbcConfig, "state_snapshot") shouldBe true
     }
 
     " drop the journal tables" in {
-      SchemasUtil.createJournalTables(journalJdbcConfig) shouldBe {}
+      SchemasUtil.createStoreTables(journalJdbcConfig) shouldBe {}
       DbUtil.tableExists(journalJdbcConfig, "event_journal") shouldBe true
       DbUtil.tableExists(journalJdbcConfig, "event_tag") shouldBe true
       DbUtil.tableExists(journalJdbcConfig, "state_snapshot") shouldBe true

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/MigrateJournalSpec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/MigrateJournalSpec.scala
@@ -152,7 +152,7 @@ class MigrateJournalSpec extends BaseSpec with ForAllTestContainer {
       migrator.nextOrderingValue() shouldBe 7L
 
       // let us create the new journal table
-      SchemasUtil.createJournalTables(journalJdbcConfig) shouldBe {}
+      SchemasUtil.createStoreTables(journalJdbcConfig) shouldBe {}
       DbUtil.tableExists(journalJdbcConfig, "event_journal") shouldBe true
       DbUtil.tableExists(journalJdbcConfig, "event_tag") shouldBe true
 
@@ -196,7 +196,7 @@ class MigrateJournalSpec extends BaseSpec with ForAllTestContainer {
       migrator.nextOrderingValue() shouldBe 7L
 
       // let us create the new journal table
-      SchemasUtil.createJournalTables(journalJdbcConfig) shouldBe {}
+      SchemasUtil.createStoreTables(journalJdbcConfig) shouldBe {}
 
       // let us migrate the data
       migrator.run() shouldBe {}
@@ -239,7 +239,7 @@ class MigrateJournalSpec extends BaseSpec with ForAllTestContainer {
       countLegacyJournal(journalJdbcConfig, legacyJournalQueries) shouldBe 6
 
       // let us create the new journal table
-      SchemasUtil.createJournalTables(journalJdbcConfig) shouldBe {}
+      SchemasUtil.createStoreTables(journalJdbcConfig) shouldBe {}
 
       // let us migrate the data
       migrator.run() shouldBe {}

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/MigrateSnapshotSpec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/MigrateSnapshotSpec.scala
@@ -114,7 +114,7 @@ class MigrateSnapshotSpec extends BaseSpec with ForAllTestContainer {
       countLegacySnapshot(journalJdbcConfig, queries) shouldBe 4
 
       // let us create the new snapshot table
-      noException shouldBe thrownBy(SchemasUtil.createJournalTables(journalJdbcConfig))
+      noException shouldBe thrownBy(SchemasUtil.createStoreTables(journalJdbcConfig))
 
       DbUtil.tableExists(journalJdbcConfig, "state_snapshot") shouldBe true
 

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/V2Spec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/V2Spec.scala
@@ -160,7 +160,7 @@ class V2Spec extends BaseSpec with ForAllTestContainer {
       countLegacySnapshot(journalJdbcConfig, legacySnapshotqueries) shouldBe 4
 
       // let us create the new journal table
-      SchemasUtil.createJournalTables(journalJdbcConfig) shouldBe {}
+      SchemasUtil.createStoreTables(journalJdbcConfig) shouldBe {}
       DbUtil.tableExists(journalJdbcConfig, "event_journal") shouldBe true
       DbUtil.tableExists(journalJdbcConfig, "event_tag") shouldBe true
       DbUtil.tableExists(journalJdbcConfig, "state_snapshot") shouldBe true

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v3/V3Spec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v3/V3Spec.scala
@@ -180,7 +180,16 @@ class V3Spec extends BaseSpec with ForAllTestContainer {
       // assert the read side offsets
       val stmt: Statement = testConn.createStatement()
       // let us query the read_side_offsets
-      val sql: String = s"""select * from read_side_offsets"""
+      val sql: String =
+        s"""select
+           |projection_name,
+           |projection_key,
+           |current_offset,
+           |manifest,
+           |mergeable,
+           |last_updated
+           |from read_side_offsets
+           |""".stripMargin
       val resultSet: ResultSet = stmt.executeQuery(sql)
 
       // we only insert three rows so we can safely loop through them

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v4/V4Spec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v4/V4Spec.scala
@@ -106,7 +106,7 @@ class V4Spec extends BaseSpec with ForAllTestContainer {
   ".upgrade" should {
     "update journal/snapshot id and manifest" in {
       // create the journal/tags tables
-      SchemasUtil.createJournalTables(journalJdbcConfig)
+      SchemasUtil.createStoreTables(journalJdbcConfig)
       DbUtil.tableExists(journalJdbcConfig, "event_journal") shouldBe true
       DbUtil.tableExists(journalJdbcConfig, "state_snapshot") shouldBe true
 


### PR DESCRIPTION
This PR fix the removal of `chiefofstate` from the read_side_offsets store table. Failure to do that will result that all events will be replayed by the registered read side which can cause some issues if for instance a readside is not implemented idempotently 