### PR TITLE
V1 migration works if old offset table does not exist

### DIFF
--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
@@ -76,8 +76,6 @@ case class V1(
   /**
    * move the data from the old read side offset store table to the new temporay offset store table by
    * reading all records into memory.
-   *
-   * @return the number of the record inserted into the table
    */
   private[v1] def migrate(): Unit = {
     val oldTable: String = transformTableName()

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
@@ -79,14 +79,15 @@ case class V1(
    *
    * @return the number of the record inserted into the table
    */
-  private def migrate(): Int = {
-    // let us fetch the records
-    val data: Seq[OffsetRow] = fetchOffsetRows()
-
-    log.info(s"num records migrating to $tempTable: ${data.size}")
-
-    // let us insert the data into the temporary table
-    insertInto(tempTable, journalJdbcConfig, data)
+  private[v1] def migrate(): Unit = {
+    val oldTable: String = transformTableName()
+    if (DbUtil.tableExists(projectionJdbcConfig, oldTable)) {
+      // let us fetch the records
+      val data: Seq[OffsetRow] = fetchOffsetRows()
+      log.info(s"num records migrating to $tempTable: ${data.size}")
+      // let us insert the data into the temporary table
+      insertInto(tempTable, journalJdbcConfig, data)
+    }
   }
 
   /**

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v1/V1Spec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v1/V1Spec.scala
@@ -184,6 +184,20 @@ class V1Spec extends BaseSpec with ForAllTestContainer {
 
       count(journalJdbcConfig) shouldBe 3
     }
+    "succeed if old table does not exist" in {
+      val v1: V1 = V1(journalJdbcConfig, projectionJdbcConfig, "not_a_table")
+      // then run beforeUpgrade
+      v1.beforeUpgrade().isSuccess shouldBe true
+      // assert no records
+      count(journalJdbcConfig) shouldBe 0
+    }
+  }
+  ".migrate" should {
+    "succeed even if old table does not exist" in {
+      val v1: V1 = V1(journalJdbcConfig, projectionJdbcConfig, "not_a_table")
+      // create the old read side offset store
+      noException shouldBe thrownBy(v1.migrate())
+    }
   }
   ".upgrade" should {
     "drop the old table and index" in {


### PR DESCRIPTION
V1 migration failed before if the read side was disabled. This makes it work even if the old read side does not exist.