### PR TITLE
0.8.1 Release branch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-parallelExecution in test := false
+test / parallelExecution := false
 Test / fork := true
 
 lazy val root: Project = project
@@ -15,9 +15,7 @@ lazy val root: Project = project
       // -J params will be added as jvm parameters
       "-J-Xms256M",
       "-J-Xmx1G",
-      "-J-XX:+UseG1GC"
-    )
-  )
+      "-J-XX:+UseG1GC"))
   .dependsOn(chiefofstate)
   .aggregate(protogen, chiefofstate, chiefofstateplugins, protogenTest, migration)
 
@@ -72,10 +70,8 @@ lazy val protogen: Project = project
       file("proto/internal"),
       // includes external protobufs (like google dependencies)
       baseDirectory.value / "target/protobuf_external"),
-    PB.targets := Seq(scalapb.gen(
-      flatPackage = false,
-      javaConversions = false,
-      grpc = true) -> (sourceManaged in Compile).value / "scalapb"))))
+    PB.targets := Seq(scalapb
+      .gen(flatPackage = false, javaConversions = false, grpc = true) -> (Compile / sourceManaged).value / "scalapb"))))
 
 lazy val protogenTest: Project = project
   .in(file("code/.protogen_test"))
@@ -90,7 +86,5 @@ lazy val protogenTest: Project = project
       file("proto/test"),
       // includes external protobufs (like google dependencies)
       baseDirectory.value / "target/protobuf_external"),
-    PB.targets := Seq(scalapb.gen(
-      flatPackage = false,
-      javaConversions = false,
-      grpc = true) -> (sourceManaged in Compile).value / "scalapb"))))
+    PB.targets := Seq(scalapb
+      .gen(flatPackage = false, javaConversions = false, grpc = true) -> (Compile / sourceManaged).value / "scalapb"))))

--- a/code/service/src/main/resources/application.conf
+++ b/code/service/src/main/resources/application.conf
@@ -407,19 +407,14 @@ chiefofstate {
 				# add here your Slick db settings
 				db {
 					driver = "org.postgresql.Driver"
-
 					user = ${jdbc-default.user}
 					user = ${?COS_READ_SIDE_OFFSET_DB_USER}
-
 					password = ${jdbc-default.password}
 					password = ${?COS_READ_SIDE_OFFSET_DB_PASSWORD}
-
 					serverName = ${jdbc-default.host}
 					serverName = ${?COS_READ_SIDE_OFFSET_DB_HOST}
-
 					portNumber = ${jdbc-default.port}
 					portNumber = ${?COS_READ_SIDE_OFFSET_DB_PORT}
-
 					databaseName = ${jdbc-default.database}
 					databaseName = ${?COS_READ_SIDE_OFFSET_DB}
 					url = "jdbc:postgresql://"${chiefofstate.migration.v1.slick.db.serverName}":"${chiefofstate.migration.v1.slick.db.portNumber}"/"${chiefofstate.migration.v1.slick.db.databaseName}"?currentSchema="${chiefofstate.migration.v1.slick.offset-store.schema}
@@ -433,11 +428,9 @@ chiefofstate {
 					idleTimeout = 60000 # 60 seconds
 					maxLifetime = 120000 # 120 seconds
 				}
-
 				offset-store {
 					schema = ${jdbc-default.schema}
 					schema = ${?COS_READ_SIDE_OFFSET_DB_SCHEMA}
-
 					table = "read_side_offsets"
 					table = ${?COS_READ_SIDE_OFFSET_STORE_TABLE}
 					use-lowercase-schema = false

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,5 +1,5 @@
-import sbt.{compilerPlugin, plugins, url, AutoPlugin, CrossVersion, Plugins, Resolver, _}
-import sbt.Keys.{resolvers, _}
+import sbt.{ compilerPlugin, plugins, url, AutoPlugin, CrossVersion, Plugins, Resolver, _ }
+import sbt.Keys.{ resolvers, _ }
 import Dependencies.Versions
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{
   headerLicense,
@@ -25,20 +25,14 @@ object Common extends AutoPlugin {
       startYear := Some(2020),
       licenses += ("MIT", new URL("https://opensource.org/licenses/MIT")),
       headerLicenseStyle := HeaderLicenseStyle.SpdxSyntax,
-      headerLicense := Some(
-        HeaderLicense.Custom(
-          """|Copyright (c) 2020 Namely Inc.
+      headerLicense := Some(HeaderLicense.Custom("""|Copyright (c) 2020 Namely Inc.
              |
-             |""".stripMargin
-        )
-      ),
+             |""".stripMargin)),
       developers += Developer(
         "contributors",
         "Contributors",
         "",
-        url("https://github.com/namely/chief-of-state/graphs/contributors")
-      )
-    )
+        url("https://github.com/namely/chief-of-state/graphs/contributors")))
 
   override def projectSettings =
     Seq(
@@ -49,24 +43,17 @@ object Common extends AutoPlugin {
         "-P:silencer:checkUnused",
         "-P:silencer:pathFilters=.protogen[/].*",
         "-P:silencer:globalFilters=Unused import;deprecated",
-        "-P:silencer:globalFilters=Marked as deprecated in proto file;Could not find any member to link;unbalanced or unclosed heading"
-      ),
+        "-P:silencer:globalFilters=Marked as deprecated in proto file;Could not find any member to link;unbalanced or unclosed heading"),
       resolvers ++= Seq(Resolver.jcenterRepo, Resolver.sonatypeRepo("public"), Resolver.sonatypeRepo("snapshots")),
       libraryDependencies ++= Seq(
-        compilerPlugin(
-          ("com.github.ghik" % "silencer-plugin" % Versions.SilencerVersion)
-            .cross(CrossVersion.full)
-        ),
-        ("com.github.ghik" % "silencer-lib" % Versions.SilencerVersion % Provided)
-          .cross(CrossVersion.full)
-      ),
+        compilerPlugin(("com.github.ghik" % "silencer-plugin" % Versions.SilencerVersion).cross(CrossVersion.full)),
+        ("com.github.ghik" % "silencer-lib" % Versions.SilencerVersion % Provided).cross(CrossVersion.full)),
       scalafmtOnCompile := true,
       // show full stack traces and test case durations
-      testOptions in Test += Tests.Argument("-oDF"),
-      logBuffered in Test := false,
+      Test / testOptions += Tests.Argument("-oDF"),
+      Test / logBuffered := false,
       coverageExcludedPackages := "<empty>;com.namely.protobuf.*;" +
-        "com.namely.chiefofstate.StartNodeBehaviour;" +
-        "com.namely.chiefofstate.StartNode;",
-      fork in Test := true
-    )
+      "com.namely.chiefofstate.StartNodeBehaviour;" +
+      "com.namely.chiefofstate.StartNode;",
+      Test / fork := true)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,12 +1,12 @@
-import sbt.{Test, _}
-import scalapb.compiler.Version.{grpcJavaVersion, scalapbVersion}
+import sbt.{ Test, _ }
+import scalapb.compiler.Version.{ grpcJavaVersion, scalapbVersion }
 
 object Dependencies {
 
   // Package versions
   object Versions {
     val ScalaVersion: String = "2.13.5"
-    val AkkaVersion: String = "2.6.13"
+    val AkkaVersion: String = "2.6.14"
     val SilencerVersion: String = "1.7.3"
     val LogbackVersion: String = "1.2.3"
     val ScalapbCommonProtoVersion: String = "1.18.1-1"
@@ -22,7 +22,7 @@ object Dependencies {
     val JaninoVersion: String = "3.1.3"
     val LogstashLogbackVersion: String = "6.3"
 
-    val OpenTelemetryVersion: String = "1.0.1"
+    val OpenTelemetryVersion: String = "1.1.0"
     val OpenTelemetryGRPCVersion: String = "1.0.1-alpha"
     val OpenTelemetryMetricsVersion: String = "1.0.1-alpha"
     val PrometheusServerVersion: String = "0.10.0"
@@ -73,8 +73,7 @@ object Dependencies {
     ("io.opentelemetry" % "opentelemetry-exporter-jaeger-thrift" % OpenTelemetryVersion).excludeAll(excludeGRPC),
     "io.opentelemetry" % "opentelemetry-exporter-prometheus" % OpenTelemetryMetricsVersion,
     "io.opentelemetry" % "opentelemetry-sdk-testing" % OpenTelemetryVersion % Test,
-    "io.prometheus" % "simpleclient_httpserver" % PrometheusServerVersion
-  )
+    "io.prometheus" % "simpleclient_httpserver" % PrometheusServerVersion)
 
   val testJars: Seq[ModuleID] = Seq(
     "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
@@ -84,6 +83,5 @@ object Dependencies {
     "io.grpc" % "grpc-testing" % grpcJavaVersion % Test,
     // test containers
     "com.dimafeng" %% "testcontainers-scala-scalatest" % Versions.TestContainers % Test,
-    "com.dimafeng" %% "testcontainers-scala-postgresql" % Versions.TestContainers % Test
-  )
+    "com.dimafeng" %% "testcontainers-scala-postgresql" % Versions.TestContainers % Test)
 }

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,5 +1,5 @@
-import sbt.Keys.{publishArtifact, skip, _}
-import sbt.{plugins, AutoPlugin, _}
+import sbt.{ plugins, AutoPlugin, _ }
+import sbt.Keys.{ publishArtifact, skip, _ }
 
 /**
  * For projects that are to be published
@@ -9,10 +9,7 @@ object Publish extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override def projectSettings = Seq(
-    publishArtifact := true,
-    Test / publishArtifact := false
-  )
+  override def projectSettings = Seq(publishArtifact := true, Test / publishArtifact := false)
 }
 
 /**
@@ -21,8 +18,5 @@ object Publish extends AutoPlugin {
 object NoPublish extends AutoPlugin {
   override def requires: Plugins = plugins.JvmPlugin
 
-  override def projectSettings = Seq(
-    publishArtifact := false,
-    skip in publish := true
-  )
+  override def projectSettings = Seq(publishArtifact := false, publish / skip := true)
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.0

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.2")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.3")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.11"
 libraryDependencies += "com.thesamet.scalapb" %% "scalapb-validate-codegen" % "0.2.2"
-


### PR DESCRIPTION
This branch will help track all `0.8.1` release tasks and PR. So far we get rid of

- https://dl.bintray.com/sbt/debian to build directly sbt from the https://github.com/sbt/sbt/releases
- sbt upgraded to 1.5.0
- Akka upgraded to 2.6.14
- sbt-protoc upgraded to 1.0.3
- OpenTelemetry upgraded to 1.1.0