### PR TITLE
Ensure span closes in case the readside call fails

### DIFF
--- a/code/service/src/main/scala/com/namely/chiefofstate/readside/RemoteReadSideProcessor.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/readside/RemoteReadSideProcessor.scala
@@ -43,13 +43,15 @@ private[readside] class RemoteReadSideProcessor(
       meta: MetaData): Try[HandleReadSideResponse] = {
 
     // start the span
-    val span: Span = GlobalOpenTelemetry
-      .getTracer(getClass.getPackage().getName())
-      .spanBuilder("RemoteReadSideProcessor.processEvent")
-      .setAttribute("component", this.getClass.getName)
-      .startSpan()
+    val span: Try[Span] = Try {
+      GlobalOpenTelemetry
+        .getTracer(getClass.getPackage().getName())
+        .spanBuilder("RemoteReadSideProcessor.processEvent")
+        .setAttribute("component", this.getClass.getName)
+        .startSpan()
+    }
 
-    val scope = span.makeCurrent()
+    val scope = span.map(_.makeCurrent())
 
     val response: Try[HandleReadSideResponse] = Try {
       val headers = new Metadata()
@@ -62,8 +64,8 @@ private[readside] class RemoteReadSideProcessor(
     }
 
     // finish the span
-    scope.close()
-    span.end()
+    scope.foreach(_.close())
+    span.foreach(_.end())
 
     // return the response
     response

--- a/code/service/src/main/scala/com/namely/chiefofstate/readside/RemoteReadSideProcessor.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/readside/RemoteReadSideProcessor.scala
@@ -41,30 +41,31 @@ private[readside] class RemoteReadSideProcessor(
       eventTag: String,
       resultingState: com.google.protobuf.any.Any,
       meta: MetaData): Try[HandleReadSideResponse] = {
-    Try {
-      // start the span
-      val span: Span = GlobalOpenTelemetry
-        .getTracer(getClass.getPackage().getName())
-        .spanBuilder("RemoteReadSideProcessor.processEvent")
-        .setAttribute("component", this.getClass.getName)
-        .startSpan()
 
-      val scope = span.makeCurrent()
+    // start the span
+    val span: Span = GlobalOpenTelemetry
+      .getTracer(getClass.getPackage().getName())
+      .spanBuilder("RemoteReadSideProcessor.processEvent")
+      .setAttribute("component", this.getClass.getName)
+      .startSpan()
 
+    val scope = span.makeCurrent()
+
+    val response: Try[HandleReadSideResponse] = Try {
       val headers = new Metadata()
       headers.put(Metadata.Key.of(COS_ENTITY_ID_HEADER, Metadata.ASCII_STRING_MARSHALLER), meta.entityId)
       headers.put(Metadata.Key.of(COS_EVENT_TAG_HEADER, Metadata.ASCII_STRING_MARSHALLER), eventTag)
 
-      val response = MetadataUtils
+      MetadataUtils
         .attachHeaders(readSideHandlerServiceBlockingStub, headers)
         .handleReadSide(HandleReadSideRequest().withEvent(event).withState(resultingState).withMeta(meta))
-
-      // finish the span
-      scope.close()
-      span.end()
-
-      // return the response
-      response
     }
+
+    // finish the span
+    scope.close()
+    span.end()
+
+    // return the response
+    response
   }
 }

--- a/code/service/src/test/scala/com/namely/chiefofstate/readside/RemoteReadSideProcessorSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/readside/RemoteReadSideProcessorSpec.scala
@@ -17,11 +17,34 @@ import com.namely.protobuf.chiefofstate.v1.readside.ReadSideHandlerServiceGrpc.R
 import com.namely.protobuf.chiefofstate.v1.tests.{ Account, AccountOpened }
 import io.grpc.Status
 import io.grpc.inprocess._
+import io.opentelemetry.api.{ GlobalOpenTelemetry, OpenTelemetry }
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.trace.data.SpanData
 
+import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.Future
+import scala.util.{ Failure, Success, Try }
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 
 class RemoteReadSideProcessorSpec extends BaseSpec {
+
+  var testExporter: InMemorySpanExporter = _
+  var openTelemetry: OpenTelemetry = _
+
+  override def beforeEach(): Unit = {
+    GlobalOpenTelemetry.resetForTest()
+
+    testExporter = InMemorySpanExporter.create
+    openTelemetry = OpenTelemetrySdk.builder
+      .setTracerProvider(SdkTracerProvider.builder.addSpanProcessor(SimpleSpanProcessor.create(testExporter)).build)
+      .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance))
+      .buildAndRegisterGlobal
+  }
 
   "RemoteReadSideProcessor" should {
     "handle events as expected" in {
@@ -69,7 +92,7 @@ class RemoteReadSideProcessorSpec extends BaseSpec {
           resultingState,
           meta)
 
-      triedHandleReadSideResponse.success.value shouldBe expected
+      triedHandleReadSideResponse shouldBe Success(expected)
     }
 
     "handle event when there is an exception" in {
@@ -88,7 +111,8 @@ class RemoteReadSideProcessorSpec extends BaseSpec {
 
       val mockImpl = mock[ReadSideHandlerServiceGrpc.ReadSideHandlerService]
 
-      (mockImpl.handleReadSide _).expects(request).returning(Future.failed(Status.INTERNAL.asException()))
+      val expectedError = Status.INTERNAL.asException()
+      (mockImpl.handleReadSide _).expects(request).returning(Future.failed(expectedError))
 
       val service = ReadSideHandlerServiceGrpc.bindService(mockImpl, global)
 
@@ -113,7 +137,13 @@ class RemoteReadSideProcessorSpec extends BaseSpec {
           resultingState,
           meta)
 
-      (triedHandleReadSideResponse.failure.exception should have).message("INTERNAL")
+      triedHandleReadSideResponse shouldBe Failure(expectedError)
+      // assert the span was closed even in case of a failure
+      testExporter
+        .getFinishedSpanItems()
+        .asScala
+        .find(_.getName() == "RemoteReadSideProcessor.processEvent")
+        .isDefined shouldBe true
     }
   }
 }


### PR DESCRIPTION
also don't fail the call to the readside in case there is an issue with the tracing.