### PR TITLE
Improve coverage, GrpcServiceImpl

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      EARTHLY_SECRETS: "CODECOV_TOKEN"
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1
+      EARTHLY_SECRETS: "CODECOV_TOKEN"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      EARTHLY_SECRETS: "CODECOV_TOKEN"
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       GIT_URL_INSTEAD_OF: "https://github.com/=git@github.com:"
       FORCE_COLOR: 1
-      EARTHLY_SECRETS: "CODECOV_TOKEN"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/code/service/src/main/scala/com/namely/chiefofstate/GrpcServiceImpl.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/GrpcServiceImpl.scala
@@ -7,28 +7,36 @@
 package com.namely.chiefofstate
 
 import akka.actor.typed.ActorRef
-import akka.cluster.sharding.typed.scaladsl.{ ClusterSharding, EntityRef }
+import akka.cluster.sharding.typed.scaladsl.ClusterSharding
+import akka.cluster.sharding.typed.scaladsl.EntityRef
 import akka.util.Timeout
 import com.google.protobuf.any
 import com.namely.chiefofstate.config.WriteSideConfig
 import com.namely.chiefofstate.plugin.PluginManager
 import com.namely.chiefofstate.serialization.MessageWithActorRef
-import com.namely.chiefofstate.telemetry.{ GrpcHeadersInterceptor, TracingHelpers }
-import com.namely.protobuf.chiefofstate.v1.internal._
+import com.namely.chiefofstate.telemetry.GrpcHeadersInterceptor
+import com.namely.chiefofstate.telemetry.TracingHelpers
+import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.Headers
+import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.{Header => LegacyHeader}
+import com.namely.protobuf.chiefofstate.v1.common.Header
 import com.namely.protobuf.chiefofstate.v1.internal.CommandReply.Reply
+import com.namely.protobuf.chiefofstate.v1.internal._
 import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
 import com.namely.protobuf.chiefofstate.v1.service._
-import io.grpc.{ Metadata, Status, StatusException }
+import io.grpc.Metadata
+import io.grpc.Status
+import io.grpc.StatusException
 import io.grpc.protobuf.StatusProto
 import io.opentelemetry.context.Context
-import org.slf4j.{ Logger, LoggerFactory }
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import scalapb.GeneratedMessage
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{ Failure, Success, Try }
-import com.namely.protobuf.chiefofstate.v1.common.Header
-import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.{ Headers, Header => LegacyHeader }
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
 class GrpcServiceImpl(clusterSharding: ClusterSharding, pluginManager: PluginManager, writeSideConfig: WriteSideConfig)(
     implicit val askTimeout: Timeout)
@@ -69,6 +77,7 @@ class GrpcServiceImpl(clusterSharding: ClusterSharding, pluginManager: PluginMan
         val newPluginData: Map[String, any.Any] = pluginData.updated(legacyHeaderKey, any.Any.pack(legacyHeaders))
 
         val remoteCommand: RemoteCommand = RemoteCommand(
+          entityId = request.entityId,
           command = request.command,
           propagatedHeaders = propagatedHeaders,
           persistedHeaders = persistedHeaders,

--- a/code/service/src/main/scala/com/namely/chiefofstate/GrpcServiceImpl.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/GrpcServiceImpl.scala
@@ -17,7 +17,7 @@ import com.namely.chiefofstate.serialization.MessageWithActorRef
 import com.namely.chiefofstate.telemetry.GrpcHeadersInterceptor
 import com.namely.chiefofstate.telemetry.TracingHelpers
 import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.Headers
-import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.{Header => LegacyHeader}
+import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.{ Header => LegacyHeader }
 import com.namely.protobuf.chiefofstate.v1.common.Header
 import com.namely.protobuf.chiefofstate.v1.internal.CommandReply.Reply
 import com.namely.protobuf.chiefofstate.v1.internal._

--- a/code/service/src/main/scala/com/namely/chiefofstate/GrpcServiceImpl.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/GrpcServiceImpl.scala
@@ -7,36 +7,28 @@
 package com.namely.chiefofstate
 
 import akka.actor.typed.ActorRef
-import akka.cluster.sharding.typed.scaladsl.ClusterSharding
-import akka.cluster.sharding.typed.scaladsl.EntityRef
+import akka.cluster.sharding.typed.scaladsl.{ClusterSharding, EntityRef}
 import akka.util.Timeout
 import com.google.protobuf.any
 import com.namely.chiefofstate.config.WriteSideConfig
 import com.namely.chiefofstate.plugin.PluginManager
 import com.namely.chiefofstate.serialization.MessageWithActorRef
-import com.namely.chiefofstate.telemetry.GrpcHeadersInterceptor
-import com.namely.chiefofstate.telemetry.TracingHelpers
-import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.Headers
-import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.{ Header => LegacyHeader }
+import com.namely.chiefofstate.telemetry.{GrpcHeadersInterceptor, TracingHelpers}
+import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.{Headers, Header => LegacyHeader}
 import com.namely.protobuf.chiefofstate.v1.common.Header
 import com.namely.protobuf.chiefofstate.v1.internal.CommandReply.Reply
 import com.namely.protobuf.chiefofstate.v1.internal._
 import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
 import com.namely.protobuf.chiefofstate.v1.service._
-import io.grpc.Metadata
-import io.grpc.Status
-import io.grpc.StatusException
+import io.grpc.{Metadata, Status, StatusException}
 import io.grpc.protobuf.StatusProto
 import io.opentelemetry.context.Context
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 import scalapb.GeneratedMessage
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 class GrpcServiceImpl(clusterSharding: ClusterSharding, pluginManager: PluginManager, writeSideConfig: WriteSideConfig)(
     implicit val askTimeout: Timeout)

--- a/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
@@ -134,6 +134,7 @@ class GrpcServiceImplSpec extends BaseActorSpec(s"""
     "inject persisted and propagated headers" in {
       // define a config that persists & propagates headers
       val headerKey = "x-custom-header"
+      val headerValue = "value"
       val customWriteConfig =
         writeSideConfig.copy(persistedHeaders = Seq(headerKey), propagatedHeaders = Seq(headerKey))
       // create the expected state
@@ -171,7 +172,6 @@ class GrpcServiceImplSpec extends BaseActorSpec(s"""
       val client = ChiefOfStateServiceGrpc.blockingStub(channel)
 
       // send request
-      val headerValue = "value"
       val requestHeaders: Metadata = GrpcHelpers.getHeaders((headerKey, headerValue))
       val request = ProcessCommandRequest(entityId = entityId).withCommand(any.Any.pack(StringValue("some-command")))
 

--- a/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
@@ -13,8 +13,8 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.cluster.sharding.typed.javadsl.{ClusterSharding => ClusterShardingJava}
 import akka.cluster.sharding.typed.scaladsl.{ClusterSharding, EntityRef, EntityTypeKey}
 import akka.cluster.sharding.typed.testkit.scaladsl.TestEntityRef
-import com.google.protobuf.{ByteString, any}
 import com.google.protobuf.wrappers.StringValue
+import com.google.protobuf.{ByteString, any}
 import com.google.rpc.code
 import com.google.rpc.error_details.BadRequest
 import com.google.rpc.status.Status
@@ -33,8 +33,8 @@ import io.grpc.protobuf.StatusProto
 import io.grpc.stub.MetadataUtils
 import io.grpc.{ManagedChannel, Metadata, StatusException}
 
-import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.{Await, ExecutionContext}
 import scala.util.Success
 
 class GrpcServiceImplSpec extends BaseActorSpec(s"""

--- a/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
@@ -11,7 +11,7 @@ import com.google.protobuf.wrappers.StringValue
 import com.google.rpc.error_details.BadRequest
 import com.google.rpc.status.Status
 import com.namely.chiefofstate.config.WriteSideConfig
-import com.namely.chiefofstate.helper.BaseSpec
+import com.namely.chiefofstate.helper.{ BaseSpec, TestConfig }
 import com.namely.protobuf.chiefofstate.v1.common.MetaData
 import com.namely.protobuf.chiefofstate.v1.internal.{ CommandReply, RemoteCommand }
 import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
@@ -24,8 +24,312 @@ import scala.concurrent.duration.Duration
 import scala.util.Success
 import com.namely.protobuf.chiefofstate.v1.common.Header
 import com.google.protobuf.ByteString
+import akka.actor.typed.Behavior
+import akka.cluster.sharding.typed.scaladsl.{ ClusterSharding, EntityRef, EntityTypeKey }
+import akka.cluster.sharding.typed.javadsl.{ ClusterSharding => ClusterShardingJava }
+import com.namely.chiefofstate.serialization.MessageWithActorRef
+import com.namely.chiefofstate.plugin.PluginManager
+import com.namely.protobuf.chiefofstate.v1.service.GetStateRequest
+import com.namely.chiefofstate.helper.BaseActorSpec
+import io.grpc.Status.Code
+import akka.cluster.typed.Cluster
+import akka.actor.typed.ActorSystem
+import akka.cluster.sharding.typed.scaladsl.Entity
+import akka.persistence.typed.PersistenceId
+import akka.actor.testkit.typed.scaladsl.TestProbe
+import scalapb.GeneratedMessage
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.TimeUnit
+import akka.actor.typed.scaladsl.Behaviors
+import com.namely.chiefofstate.serialization.ScalaMessage
+import akka.cluster.sharding.typed.testkit.scaladsl.TestEntityRef
+import com.namely.protobuf.chiefofstate.v1.internal.SendCommand
+import com.google.rpc.code
+import io.grpc.StatusRuntimeException
+import com.namely.protobuf.chiefofstate.v1.service.ChiefOfStateServiceGrpc
+import scala.concurrent.ExecutionContext
+import io.grpc.inprocess.InProcessServerBuilder
+import com.namely.chiefofstate.telemetry.GrpcHeadersInterceptor
+import io.grpc.ManagedChannel
+import io.grpc.inprocess.InProcessChannelBuilder
+import com.namely.chiefofstate.helper.GrpcHelpers
+import io.grpc.stub.MetadataUtils
+import com.namely.protobuf.chiefofstate.v1.internal.GetStateCommand
 
-class GrpcServiceImplSpec extends BaseSpec {
+class GrpcServiceImplSpec extends BaseActorSpec(s"""
+      akka.cluster.sharding.number-of-shards = 1
+      akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+      akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+      akka.persistence.snapshot-store.local.dir = "tmp/snapshot"
+    """) {
+
+  // creates a trait to mock cluster sharding
+  // this is necessary as the scaladsl ClusterSharding uses a self-type
+  // to require mixing with the java ClusterSharding
+  // https://docs.scala-lang.org/tour/self-types.html
+  trait FakeClusterSharding extends ClusterShardingJava with ClusterSharding
+
+  // creates a mock cluster sharding that returns a specific EntityRef
+  def getClusterShard(output: EntityRef[MessageWithActorRef]): ClusterSharding = {
+    val clusterSharding = mock[FakeClusterSharding]
+
+    ((a: EntityTypeKey[MessageWithActorRef], b: String) => clusterSharding.entityRefFor(a, b))
+      .expects(AggregateRoot.TypeKey, *)
+      .returning(output)
+      .repeat(1)
+
+    clusterSharding
+  }
+
+  val actorSystem: ActorSystem[Nothing] = testKit.system
+  val replyTimeout: FiniteDuration = FiniteDuration(1, TimeUnit.SECONDS)
+
+  val writeSideConfig: WriteSideConfig = WriteSideConfig(
+    host = "",
+    port = 0,
+    useTls = false,
+    enableProtoValidation = false,
+    eventsProtos = Seq(),
+    statesProtos = Seq(),
+    propagatedHeaders = Seq(),
+    persistedHeaders = Seq())
+
+  val pluginManager: PluginManager = PluginManager(Seq())
+
+  val cosConfig = TestConfig.cosConfig
+
+  ".processCommand" should {
+    "require entity ID" in {
+      val clusterSharding: ClusterSharding = mock[FakeClusterSharding]
+      val impl = new GrpcServiceImpl(clusterSharding, pluginManager, writeSideConfig)
+
+      val request = ProcessCommandRequest(entityId = "")
+
+      val actualErr = intercept[StatusException] {
+        Await.result(impl.processCommand(request), Duration.Inf)
+      }
+
+      actualErr.getStatus().getCode() shouldBe Code.INVALID_ARGUMENT
+      actualErr.getStatus().getDescription() shouldBe "empty entity ID"
+    }
+    "handles happy returns" in {
+      // create the expected state
+      val expectedState =
+        StateWrapper().withState(any.Any.pack(StringValue("some state"))).withMeta(MetaData().withRevisionNumber(2))
+      // create a behavior that returns a state
+      val mockedBehavior = Behaviors.receiveMessage[ScalaMessage] { case MessageWithActorRef(message, replyTo) =>
+        replyTo ! CommandReply().withState(expectedState)
+        Behaviors.same
+      }
+      // create a mocked entity & probe to run this behavior
+      val probe = testKit.createTestProbe[ScalaMessage]()
+      val mockedEntity = testKit.spawn(Behaviors.monitor(probe.ref, mockedBehavior))
+      // create mocked cluster sharding with the actor
+      val entityId: String = "id-1"
+      val typeKey = EntityTypeKey[MessageWithActorRef](entityId)
+      val testEntityRef: EntityRef[MessageWithActorRef] = TestEntityRef(typeKey, entityId, mockedEntity.ref)
+      val clusterSharding = getClusterShard(testEntityRef)
+      // instantiate the service
+      val impl = new GrpcServiceImpl(clusterSharding, pluginManager, writeSideConfig)
+      // call method
+      val request =
+        ProcessCommandRequest().withEntityId(entityId).withCommand(any.Any.pack(StringValue("some-command")))
+      val sendFuture = impl.processCommand(request)
+
+      // assert message sent to actor
+      val akkaReceived = probe.receiveMessage()
+
+      val remoteCommand =
+        akkaReceived.asInstanceOf[MessageWithActorRef].message.asInstanceOf[SendCommand].getRemoteCommand
+
+      remoteCommand.entityId shouldBe request.entityId
+      remoteCommand.getCommand shouldBe request.getCommand
+
+      // assert response
+      val response = Await.result(sendFuture, Duration.Inf)
+      response.getState shouldBe expectedState.getState
+      response.getMeta shouldBe expectedState.getMeta
+    }
+    "inject persisted and propagated headers" in {
+      // define a config that persists & propagates headers
+      val headerKey = "x-custom-header"
+      val customWriteConfig =
+        writeSideConfig.copy(persistedHeaders = Seq(headerKey), propagatedHeaders = Seq(headerKey))
+      // create the expected state
+      val entityId = "some-entity"
+      val expectedState =
+        StateWrapper().withState(any.Any.pack(StringValue("some state"))).withMeta(MetaData().withRevisionNumber(2))
+      // create a behavior that returns the state
+      val mockedBehavior = Behaviors.receiveMessage[ScalaMessage] { case MessageWithActorRef(message, replyTo) =>
+        replyTo ! CommandReply().withState(expectedState)
+        Behaviors.same
+      }
+      // create a mocked entity & probe to run this behavior
+      val probe = testKit.createTestProbe[ScalaMessage]()
+      val mockedEntity = testKit.spawn(Behaviors.monitor(probe.ref, mockedBehavior))
+      // create mocked cluster sharding with the actor
+      val typeKey = EntityTypeKey[MessageWithActorRef](entityId)
+      val testEntityRef: EntityRef[MessageWithActorRef] = TestEntityRef(typeKey, entityId, mockedEntity.ref)
+      val clusterSharding = getClusterShard(testEntityRef)
+      // instantiate the service
+      val impl = new GrpcServiceImpl(clusterSharding, pluginManager, customWriteConfig)
+      // bind service and intercept headers
+      val serverName: String = InProcessServerBuilder.generateName();
+      val service = ChiefOfStateServiceGrpc.bindService(impl, ExecutionContext.global)
+      closeables.register(
+        InProcessServerBuilder
+          .forName(serverName)
+          .directExecutor()
+          .addService(service)
+          .intercept(GrpcHeadersInterceptor)
+          .build()
+          .start())
+      // create a client
+      val channel: ManagedChannel =
+        closeables.register(InProcessChannelBuilder.forName(serverName).directExecutor().build())
+      val client = ChiefOfStateServiceGrpc.blockingStub(channel)
+
+      // send request
+      val headerValue = "value"
+      val requestHeaders: Metadata = GrpcHelpers.getHeaders((headerKey, headerValue))
+      val request = ProcessCommandRequest(entityId = entityId).withCommand(any.Any.pack(StringValue("some-command")))
+
+      MetadataUtils.attachHeaders(client, requestHeaders).processCommand(request)
+
+      // assert headers sent to actor
+      val remoteCommand: RemoteCommand =
+        probe.receiveMessage().asInstanceOf[MessageWithActorRef].message.asInstanceOf[SendCommand].getRemoteCommand
+
+      remoteCommand.persistedHeaders.map(_.key).toSeq shouldBe Seq(headerKey)
+      remoteCommand.persistedHeaders.map(_.getStringValue).toSeq shouldBe Seq(headerValue)
+    }
+    "handle failure responses" in {
+      // create the expected error
+      val errorStatus = Status().withCode(code.Code.NOT_FOUND.value)
+      // create a behavior that returns a state
+      val mockedBehavior = Behaviors.receiveMessage[ScalaMessage] { case MessageWithActorRef(message, replyTo) =>
+        replyTo ! CommandReply().withError(errorStatus)
+        Behaviors.same
+      }
+      // create a mocked entity & probe to run this behavior
+      val probe = testKit.createTestProbe[ScalaMessage]()
+      val mockedEntity = testKit.spawn(Behaviors.monitor(probe.ref, mockedBehavior))
+      // create mocked cluster sharding with the actor
+      val entityId: String = "id-1"
+      val typeKey = EntityTypeKey[MessageWithActorRef](entityId)
+      val testEntityRef: EntityRef[MessageWithActorRef] = TestEntityRef(typeKey, entityId, mockedEntity.ref)
+      val clusterSharding = getClusterShard(testEntityRef)
+      // instantiate the service
+      val impl = new GrpcServiceImpl(clusterSharding, pluginManager, writeSideConfig)
+      // call method
+      val request = ProcessCommandRequest().withEntityId(entityId)
+      val sendFuture = impl.processCommand(request)
+      // assert message sent to actor
+      val akkaMsg = probe.receiveMessage()
+      akkaMsg.shouldBe(an[MessageWithActorRef])
+      akkaMsg
+        .asInstanceOf[MessageWithActorRef]
+        .message
+        .asInstanceOf[SendCommand]
+        .getRemoteCommand
+        .entityId shouldBe entityId
+
+      // assert response
+      val actualError = intercept[StatusException] {
+        Await.result(sendFuture, Duration.Inf)
+      }
+      Util.toRpcStatus(actualError.getStatus) shouldBe errorStatus
+    }
+  }
+
+  ".getState" should {
+    "require entity ID" in {
+      val clusterSharding: ClusterSharding = mock[FakeClusterSharding]
+      val impl = new GrpcServiceImpl(clusterSharding, pluginManager, writeSideConfig)
+
+      val request = GetStateRequest(entityId = "")
+      val actualErr = intercept[StatusException] {
+        Await.result(impl.getState(request), Duration.Inf)
+      }
+
+      actualErr.getStatus().getCode() shouldBe Code.INVALID_ARGUMENT
+      actualErr.getStatus().getDescription() shouldBe "empty entity ID"
+    }
+    "handle happy return" in {
+      // create the expected state
+      val expectedState =
+        StateWrapper().withState(any.Any.pack(StringValue("some state"))).withMeta(MetaData().withRevisionNumber(2))
+      // create a behavior that returns a state
+      val mockedBehavior = Behaviors.receiveMessage[ScalaMessage] { case MessageWithActorRef(message, replyTo) =>
+        replyTo ! CommandReply().withState(expectedState)
+        Behaviors.same
+      }
+      // create a mocked entity & probe to run this behavior
+      val probe = testKit.createTestProbe[ScalaMessage]()
+      val mockedEntity = testKit.spawn(Behaviors.monitor(probe.ref, mockedBehavior))
+      // create mocked cluster sharding with the actor
+      val entityId: String = "id-1"
+      val typeKey = EntityTypeKey[MessageWithActorRef](entityId)
+      val testEntityRef: EntityRef[MessageWithActorRef] = TestEntityRef(typeKey, entityId, mockedEntity.ref)
+      val clusterSharding = getClusterShard(testEntityRef)
+      // instantiate the service
+      val impl = new GrpcServiceImpl(clusterSharding, pluginManager, writeSideConfig)
+      // call method
+      val request = GetStateRequest().withEntityId(entityId)
+      val sendFuture = impl.getState(request)
+      // assert message sent to actor
+      val akkaResponse = probe.receiveMessage()
+      akkaResponse.shouldBe(an[MessageWithActorRef])
+      akkaResponse
+        .asInstanceOf[MessageWithActorRef]
+        .message
+        .asInstanceOf[SendCommand]
+        .getGetStateCommand
+        .entityId shouldBe entityId
+
+      // assert response
+      val response = Await.result(sendFuture, Duration.Inf)
+      response.getState shouldBe expectedState.getState
+      response.getMeta shouldBe expectedState.getMeta
+    }
+    "handle failure responses" in {
+      // create the expected error
+      val errorStatus = Status().withCode(code.Code.NOT_FOUND.value)
+      // create a behavior that returns a state
+      val mockedBehavior = Behaviors.receiveMessage[ScalaMessage] { case MessageWithActorRef(message, replyTo) =>
+        replyTo ! CommandReply().withError(errorStatus)
+        Behaviors.same
+      }
+      // create a mocked entity & probe to run this behavior
+      val probe = testKit.createTestProbe[ScalaMessage]()
+      val mockedEntity = testKit.spawn(Behaviors.monitor(probe.ref, mockedBehavior))
+      // create mocked cluster sharding with the actor
+      val entityId: String = "id-1"
+      val typeKey = EntityTypeKey[MessageWithActorRef](entityId)
+      val testEntityRef: EntityRef[MessageWithActorRef] = TestEntityRef(typeKey, entityId, mockedEntity.ref)
+      val clusterSharding = getClusterShard(testEntityRef)
+      // instantiate the service
+      val impl = new GrpcServiceImpl(clusterSharding, pluginManager, writeSideConfig)
+      // call method
+      val request = GetStateRequest().withEntityId(entityId)
+      val sendFuture = impl.getState(request)
+      // assert message sent to actor
+      val akkaMsg = probe.receiveMessage()
+      akkaMsg.shouldBe(an[MessageWithActorRef])
+      akkaMsg
+        .asInstanceOf[MessageWithActorRef]
+        .message
+        .asInstanceOf[SendCommand]
+        .getGetStateCommand
+        .entityId shouldBe entityId
+
+      // assert response
+      val actualError = intercept[StatusException] {
+        Await.result(sendFuture, Duration.Inf)
+      }
+      Util.toRpcStatus(actualError.getStatus) shouldBe errorStatus
+    }
+  }
 
   ".requireEntityId" should {
     "fail if entity missing" in {

--- a/code/service/src/test/scala/com/namely/chiefofstate/helper/TestConfig.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/helper/TestConfig.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Namely Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.namely.chiefofstate.helper
+
+import com.namely.chiefofstate.config.CosConfig
+import com.typesafe.config.{ Config, ConfigFactory }
+
+object TestConfig {
+  val config: Config = ConfigFactory.parseString(s"""
+    akka.cluster.sharding.number-of-shards = 1
+    chiefofstate {
+      service-name = "chiefofstate"
+      ask-timeout = 5
+      snapshot-criteria {
+        disable-snapshot = false
+        retention-frequency = 1
+        retention-number = 1
+        delete-events-on-snapshot = false
+      }
+      events {
+        tagname: "cos"
+      }
+      grpc {
+        client {
+          deadline-timeout = 3000
+        }
+        server {
+          address = "0.0.0.0"
+          port = 9000
+        }
+      }
+      write-side {
+        host = "localhost"
+        port = 6000
+        use-tls = false
+        enable-protos-validation = false
+        states-protos = ""
+        events-protos = ""
+        propagated-headers = ""
+        persisted-headers = ""
+      }
+      read-side {
+        # set this value to true whenever a readSide config is set
+        enabled = false
+      }
+      telemetry {
+        namespace = ""
+        otlp_endpoint = ""
+        trace_propagators = "b3multi"
+      }
+    }
+  """)
+
+  val cosConfig = CosConfig(config)
+}


### PR DESCRIPTION
Improves coverage for the GrpcServiceImpl. This uses a neat pattern that I found [here](https://github.com/akka/akka/pull/29336/files) for mocking the cluster sharding without running multi-node tests

![image](https://user-images.githubusercontent.com/6268545/116653435-2ef42a80-a955-11eb-8c07-6feb54a8da94.png)

relates to #137 