### PR TITLE
Bind Akka Management API to 0.0.0.0 for istio

### DIFF
--- a/code/service/src/main/resources/application.conf
+++ b/code/service/src/main/resources/application.conf
@@ -200,10 +200,11 @@ akka {
 		}
 	}
 
+	# these settings bind Akka management to 0.0.0.0 so that k8s health checks
+	# work when running behind istio proxy
+	# https://doc.akka.io/docs/akka-management/current/akka-management.html
 	management.http.hostname = "0.0.0.0"
-	management.http.hostname = "${?AKKA_MANAGEMENT_HOST}"
 	management.http.bind-hostname = "0.0.0.0"
-	management.http.bind-hostname = ${?AKKA_MANAGEMENT_BIND_HOST}
   	management.http.bind-port = 8558
 }
 

--- a/code/service/src/main/resources/application.conf
+++ b/code/service/src/main/resources/application.conf
@@ -199,6 +199,12 @@ akka {
 			retry-delay = 1 s
 		}
 	}
+
+	management.http.hostname = "0.0.0.0"
+	management.http.hostname = "${?AKKA_MANAGEMENT_HOST}"
+	management.http.bind-hostname = "0.0.0.0"
+	management.http.bind-hostname = ${?AKKA_MANAGEMENT_BIND_HOST}
+  	management.http.bind-port = 8558
 }
 
 # general slick configuration


### PR DESCRIPTION
This PR binds Akka Management api to `0.0.0.0`. By default in k8s, Akka Management binds the management API to the pod IP, not `0.0.0.0` or `localhost`, so istio was unable to reach COS for health checks.

Docs:
- https://doc.akka.io/docs/akka-management/current/akka-management.html
- https://doc.akka.io/docs/akka-management/current/bootstrap/istio.html