### PR TITLE
Fix akka management hostname configuration

### DIFF
--- a/code/service/src/main/resources/application.conf
+++ b/code/service/src/main/resources/application.conf
@@ -203,7 +203,6 @@ akka {
 	# these settings bind Akka management to 0.0.0.0 so that k8s health checks
 	# work when running behind istio proxy
 	# https://doc.akka.io/docs/akka-management/current/akka-management.html
-	management.http.hostname = "0.0.0.0"
 	management.http.bind-hostname = "0.0.0.0"
   	management.http.bind-port = 8558
 }

--- a/code/service/src/main/resources/docker.conf
+++ b/code/service/src/main/resources/docker.conf
@@ -3,10 +3,7 @@ include "application.conf"
 deployment-mode = "docker"
 
 akka.management {
-	http {
-		hostname = "<hostname>"
-		bind-hostname = "0.0.0.0"
-	}
+	http.hostname = "<hostname>"
 	cluster {
 		bootstrap {
 			contact-point-discovery {


### PR DESCRIPTION
We previously changed the default hostname to 0.0.0.0 to bind to all ports, but we need replicas to have unique hostnames for cluster formation.
This PR removes this default configuration and standardizes the docker configuration to make use of the default bind hostname.