### PR TITLE
Preparation for 0.9.0 release

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.0.3
+version = 3.0.2
 
 style = defaultWithAlign
 

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/DbUtil.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/DbUtil.scala
@@ -7,9 +7,9 @@
 package com.namely.chiefofstate.migration
 
 import slick.basic.DatabaseConfig
-import slick.jdbc.meta.MTable
 import slick.jdbc.JdbcProfile
 import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.meta.MTable
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/Migrator.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/Migrator.scala
@@ -14,8 +14,8 @@ import slick.sql.SqlAction
 
 import java.time.Instant
 import scala.collection.mutable
-import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future }
 import scala.util.{ Success, Try }
 
 /**

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v1/V1.scala
@@ -6,7 +6,6 @@
 
 package com.namely.chiefofstate.migration.versions.v1
 
-import com.namely.chiefofstate.migration.{ DbUtil, StringImprovements, Version }
 import com.namely.chiefofstate.migration.versions.v1.V1.{
   createTable,
   insertInto,
@@ -14,11 +13,12 @@ import com.namely.chiefofstate.migration.versions.v1.V1.{
   tempTable,
   OffsetRow
 }
+import com.namely.chiefofstate.migration.{ DbUtil, StringImprovements, Version }
 import org.slf4j.{ Logger, LoggerFactory }
 import slick.basic.DatabaseConfig
 import slick.dbio.DBIO
-import slick.jdbc.{ GetResult, JdbcProfile }
 import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.{ GetResult, JdbcProfile }
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v2/MigrateJournal.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v2/MigrateJournal.scala
@@ -24,7 +24,6 @@ import slick.dbio.Effect
 import slick.jdbc.PostgresProfile.api._
 import slick.jdbc.{ JdbcBackend, JdbcProfile, ResultSetConcurrency, ResultSetType }
 import slick.sql.FixedSqlAction
-import slickProfile.api._
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, ExecutionContextExecutor, Future }

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v2/MigrateSnapshot.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v2/MigrateSnapshot.scala
@@ -22,7 +22,6 @@ import org.slf4j.{ Logger, LoggerFactory }
 import slick.basic.DatabasePublisher
 import slick.jdbc.PostgresProfile.api._
 import slick.jdbc.{ JdbcBackend, JdbcProfile, ResultSetConcurrency, ResultSetType }
-import slickProfile.api._
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, ExecutionContextExecutor, Future }

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v4/V4.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v4/V4.scala
@@ -6,7 +6,7 @@
 
 package com.namely.chiefofstate.migration.versions.v4
 
-import com.namely.chiefofstate.migration.{ SchemasUtil, Version }
+import com.namely.chiefofstate.migration.Version
 import com.namely.protobuf.chiefofstate.v1.persistence.{ EventWrapper, StateWrapper }
 import org.slf4j.{ Logger, LoggerFactory }
 import slick.basic.DatabaseConfig

--- a/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v5/V5.scala
+++ b/code/migration/src/main/scala/com/namely/chiefofstate/migration/versions/v5/V5.scala
@@ -6,25 +6,26 @@
 
 package com.namely.chiefofstate.migration.versions.v5
 
-import com.namely.chiefofstate.migration.{ SchemasUtil, Version }
-import com.namely.protobuf.chiefofstate.v1.persistence.{ EventWrapper, StateWrapper }
-import org.slf4j.{ Logger, LoggerFactory }
-import slick.basic.DatabaseConfig
-import slick.dbio.DBIO
-import slick.jdbc.{ GetResult, JdbcProfile, ResultSetConcurrency, ResultSetType }
-import slick.jdbc.PostgresProfile.api._
-import V5.log
-import scala.util.Try
-import akka.stream.scaladsl.Source
-import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, Future }
-import akka.actor.typed.ActorSystem
 import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.stream.scaladsl.Source
+import com.namely.chiefofstate.migration.versions.v5.V5.log
+import com.namely.chiefofstate.migration.{ SchemasUtil, Version }
 import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.{
   Header => LegacyHeader,
   Headers => LegacyHeaders
 }
 import com.namely.protobuf.chiefofstate.v1.common.Header
+import com.namely.protobuf.chiefofstate.v1.persistence.{ EventWrapper, StateWrapper }
+import org.slf4j.{ Logger, LoggerFactory }
+import slick.basic.DatabaseConfig
+import slick.dbio.DBIO
+import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.{ GetResult, JdbcProfile, ResultSetConcurrency, ResultSetType }
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future }
+import scala.util.Try
 
 case class V5(system: ActorSystem[_], journalJdbcConfig: DatabaseConfig[JdbcProfile]) extends Version {
   override def versionNumber: Int = 5

--- a/code/migration/src/test/resources/migration.conf
+++ b/code/migration/src/test/resources/migration.conf
@@ -1,236 +1,236 @@
 jdbc-default {
-	schema = "cos"
+  schema = "cos"
 }
 akka {
-	loglevel = ERROR
-	log-dead-letters-during-shutdown = on
-	log-dead-letters = on
-	actor {
-		serialize-messages = off
-		debug {
-			receive = on // log all messages sent to an actor if that actors receive method is a LoggingReceive
-			autoreceive = on // log all special messages like Kill, PoisoffPill etc sent to all actors
-			lifecycle = on // log all actor lifecycle events of all actors
-			fsm = off // enable logging of all events, transitioffs and timers of FSM Actors that extend LoggingFSM
-			event-stream = on // enable logging of subscriptions (subscribe/unsubscribe) on the ActorSystem.eventStream
-		}
-		serializers {
-			proto = "akka.remote.serialization.ProtobufSerializer"
-		}
-		serialization-bindings {
-			# state is serialized using protobuf
-			"scalapb.GeneratedMessage" = proto
-			"com.google.protobuf.Message" = proto
-		}
+  loglevel = ERROR
+  log-dead-letters-during-shutdown = on
+  log-dead-letters = on
+  actor {
+    serialize-messages = off
+    debug {
+      receive = on // log all messages sent to an actor if that actors receive method is a LoggingReceive
+      autoreceive = on // log all special messages like Kill, PoisoffPill etc sent to all actors
+      lifecycle = on // log all actor lifecycle events of all actors
+      fsm = off // enable logging of all events, transitioffs and timers of FSM Actors that extend LoggingFSM
+      event-stream = on // enable logging of subscriptions (subscribe/unsubscribe) on the ActorSystem.eventStream
+    }
+    serializers {
+      proto = "akka.remote.serialization.ProtobufSerializer"
+    }
+    serialization-bindings {
+      # state is serialized using protobuf
+      "scalapb.GeneratedMessage" = proto
+      "com.google.protobuf.Message" = proto
+    }
 
-		# This will stop the guardian actor in case of any exception which will therefore
-		# shutdown the whole actor system
-		guardian-supervisor-strategy = "akka.actor.StoppingSupervisorStrategy"
-	}
+    # This will stop the guardian actor in case of any exception which will therefore
+    # shutdown the whole actor system
+    guardian-supervisor-strategy = "akka.actor.StoppingSupervisorStrategy"
+  }
 
-	persistence {
-		# akka persistence jdbc
-		journal.plugin = "jdbc-journal"
-		snapshot-store.plugin = "jdbc-snapshot-store"
-	}
+  persistence {
+    # akka persistence jdbc
+    journal.plugin = "jdbc-journal"
+    snapshot-store.plugin = "jdbc-snapshot-store"
+  }
 
-	coordinated-shutdown {
-		terminate-actor-system = off
-		exit-jvm = off
-		run-by-actor-system-terminate = off
-		run-by-jvm-shutdown-hook = off
-	}
+  coordinated-shutdown {
+    terminate-actor-system = off
+    exit-jvm = off
+    run-by-actor-system-terminate = off
+    run-by-jvm-shutdown-hook = off
+  }
 
-	projection {
-		jdbc {
-			# choose one of: mysql-dialect, postgres-dialect, mssql-dialect, oracle-dialect or h2-dialect (testing)
-			dialect = "postgres-dialect"
-			blocking-jdbc-dispatcher {
-				type = Dispatcher
-				executor = "thread-pool-executor"
-				thread-pool-executor {
-					fixed-pool-size = 1
-				}
-				throughput = 1
-			}
+  projection {
+    jdbc {
+      # choose one of: mysql-dialect, postgres-dialect, mssql-dialect, oracle-dialect or h2-dialect (testing)
+      dialect = "postgres-dialect"
+      blocking-jdbc-dispatcher {
+        type = Dispatcher
+        executor = "thread-pool-executor"
+        thread-pool-executor {
+          fixed-pool-size = 1
+        }
+        throughput = 1
+      }
 
-			offset-store {
-				# set this to your database schema if applicable, empty by default
-				schema = ${jdbc-default.schema}
-				# the database table name for the offset store
-				table = "read_side_offsets"
-				# Use lowercase table and column names.
-				use-lowercase-schema = true
-			}
-			debug.verbose-offset-store-logging = false
-		}
+      offset-store {
+        # set this to your database schema if applicable, empty by default
+        schema = ${jdbc-default.schema}
+        # the database table name for the offset store
+        table = "read_side_offsets"
+        # Use lowercase table and column names.
+        use-lowercase-schema = true
+      }
+      debug.verbose-offset-store-logging = false
+    }
 
-		restart-backoff {
-			min-backoff = 3s
-			max-backoff = 30s
-			random-factor = 0.2
-			max-restarts = -1
-		}
-		recovery-strategy {
-			strategy = fail
-			retries = 5
-			retry-delay = 1 s
-		}
-	}
+    restart-backoff {
+      min-backoff = 3s
+      max-backoff = 30s
+      random-factor = 0.2
+      max-restarts = -1
+    }
+    recovery-strategy {
+      strategy = fail
+      retries = 5
+      retry-delay = 1 s
+    }
+  }
 }
 
 
 # general slick configuration
 write-side-slick {
-	profile = "slick.jdbc.PostgresProfile$"
-	db {
-		connectionPool = disabled
-		driver = "org.postgresql.Driver"
-		user = ""
-		password = ""
-		serverName = ""
-		databaseName = ""
-		url = ""
-	}
+  profile = "slick.jdbc.PostgresProfile$"
+  db {
+    connectionPool = disabled
+    driver = "org.postgresql.Driver"
+    user = ""
+    password = ""
+    serverName = ""
+    databaseName = ""
+    url = ""
+  }
 }
 
 jdbc-journal {
-	tables {
-		# Only used in pre 5.0.0 for backward-compatibility
-		# ref: https://github.com/akka/akka-persistence-jdbc/blob/v5.0.0/core/src/main/resources/reference.conf
-		legacy_journal {
-			tableName = "journal"
-			schemaName = ${jdbc-default.schema}
-			columnNames {
-				ordering = "ordering"
-				deleted = "deleted"
-				persistenceId = "persistence_id"
-				sequenceNumber = "sequence_number"
-				created = "created"
-				tags = "tags"
-				message = "message"
-			}
-		}
+  tables {
+    # Only used in pre 5.0.0 for backward-compatibility
+    # ref: https://github.com/akka/akka-persistence-jdbc/blob/v5.0.0/core/src/main/resources/reference.conf
+    legacy_journal {
+      tableName = "journal"
+      schemaName = ${jdbc-default.schema}
+      columnNames {
+        ordering = "ordering"
+        deleted = "deleted"
+        persistenceId = "persistence_id"
+        sequenceNumber = "sequence_number"
+        created = "created"
+        tags = "tags"
+        message = "message"
+      }
+    }
 
-		# this is the new going forward
-		# ref: https://github.com/akka/akka-persistence-jdbc/blob/v5.0.0/core/src/main/resources/reference.conf
-		event_journal {
-			tableName = "event_journal"
-			schemaName = ${jdbc-default.schema}
-			columnNames {
-				ordering = "ordering"
-				deleted = "deleted"
-				persistenceId = "persistence_id"
-				sequenceNumber = "sequence_number"
-				writer = "writer"
-				writeTimestamp = "write_timestamp"
-				adapterManifest = "adapter_manifest"
-				eventPayload = "event_payload"
-				eventSerId = "event_ser_id"
-				eventSerManifest = "event_ser_manifest"
-				metaPayload = "meta_payload"
-				metaSerId = "meta_ser_id"
-				metaSerManifest = "meta_ser_manifest"
-			}
-		}
+    # this is the new going forward
+    # ref: https://github.com/akka/akka-persistence-jdbc/blob/v5.0.0/core/src/main/resources/reference.conf
+    event_journal {
+      tableName = "event_journal"
+      schemaName = ${jdbc-default.schema}
+      columnNames {
+        ordering = "ordering"
+        deleted = "deleted"
+        persistenceId = "persistence_id"
+        sequenceNumber = "sequence_number"
+        writer = "writer"
+        writeTimestamp = "write_timestamp"
+        adapterManifest = "adapter_manifest"
+        eventPayload = "event_payload"
+        eventSerId = "event_ser_id"
+        eventSerManifest = "event_ser_manifest"
+        metaPayload = "meta_payload"
+        metaSerId = "meta_ser_id"
+        metaSerManifest = "meta_ser_manifest"
+      }
+    }
 
-		event_tag {
-			tableName = "event_tag"
-			schemaName = ${jdbc-default.schema}
-			columnNames {
-				eventId = "event_id"
-				tag = "tag"
-			}
-		}
-	}
-	tagSeparator = ","
-	bufferSize = 1000
-	batchSize = 400
-	replayBatchSize = 400
-	parallelism = 8
-	logicalDelete = true
-	dao = "akka.persistence.jdbc.journal.dao.DefaultJournalDao"
-	slick = ${write-side-slick}
+    event_tag {
+      tableName = "event_tag"
+      schemaName = ${jdbc-default.schema}
+      columnNames {
+        eventId = "event_id"
+        tag = "tag"
+      }
+    }
+  }
+  tagSeparator = ","
+  bufferSize = 1000
+  batchSize = 400
+  replayBatchSize = 400
+  parallelism = 8
+  logicalDelete = true
+  dao = "akka.persistence.jdbc.journal.dao.DefaultJournalDao"
+  slick = ${write-side-slick}
 }
 
 # the akka-persistence-query provider in use
 jdbc-read-journal {
-	# New events are retrieved (polled) with this interval.
-	refresh-interval = "1s"
-	# How many events to fetch in one query (replay) and keep buffered until they
-	# are delivered downstreams.
-	max-buffer-size = "500"
-	tables {
-		legacy_journal = ${jdbc-journal.tables.legacy_journal}
-		event_journal = ${jdbc-journal.tables.event_journal}
-		event_tag = ${jdbc-journal.tables.event_tag}
-	}
+  # New events are retrieved (polled) with this interval.
+  refresh-interval = "1s"
+  # How many events to fetch in one query (replay) and keep buffered until they
+  # are delivered downstreams.
+  max-buffer-size = "500"
+  tables {
+    legacy_journal = ${jdbc-journal.tables.legacy_journal}
+    event_journal = ${jdbc-journal.tables.event_journal}
+    event_tag = ${jdbc-journal.tables.event_tag}
+  }
 
-	tagSeparator = ","
-	# if true, queries will include logically deleted events
-	# should not be configured directly, but through property akka-persistence-jdbc.logicalDelete.enable
-	# in order to keep consistent behavior over write/read sides
-	includeLogicallyDeleted = true
+  tagSeparator = ","
+  # if true, queries will include logically deleted events
+  # should not be configured directly, but through property akka-persistence-jdbc.logicalDelete.enable
+  # in order to keep consistent behavior over write/read sides
+  includeLogicallyDeleted = true
 
-	# Settings for determining if ids (ordering column) in the journal are out of sequence.
-	journal-sequence-retrieval {
-		# The maximum number of ids that will be retrieved in each batch
-		batch-size = 10000
-		# In case a number in the sequence is missing, this is the ammount of retries that will be done to see
-		# if the number is still found. Note that the time after which a number in the sequence is assumed missing is
-		# equal to maxTries * queryDelay
-		# (maxTries may not be zero)
-		max-tries = 10
-		# How often the actor will query for new data
-		query-delay = 1 second
-		# The maximum backoff time before trying to query again in case of database failures
-		max-backoff-query-delay = 1 minute
-		# The ask timeout to use when querying the journal sequence actor, the actor should normally repond very quickly,
-		# since it always replies with its current internal state
-		ask-timeout = 1 second
-	}
+  # Settings for determining if ids (ordering column) in the journal are out of sequence.
+  journal-sequence-retrieval {
+    # The maximum number of ids that will be retrieved in each batch
+    batch-size = 10000
+    # In case a number in the sequence is missing, this is the ammount of retries that will be done to see
+    # if the number is still found. Note that the time after which a number in the sequence is assumed missing is
+    # equal to maxTries * queryDelay
+    # (maxTries may not be zero)
+    max-tries = 10
+    # How often the actor will query for new data
+    query-delay = 1 second
+    # The maximum backoff time before trying to query again in case of database failures
+    max-backoff-query-delay = 1 minute
+    # The ask timeout to use when querying the journal sequence actor, the actor should normally repond very quickly,
+    # since it always replies with its current internal state
+    ask-timeout = 1 second
+  }
 
-	dao = "akka.persistence.jdbc.query.dao.DefaultReadJournalDao"
-	slick = ${write-side-slick}
+  dao = "akka.persistence.jdbc.query.dao.DefaultReadJournalDao"
+  slick = ${write-side-slick}
 }
 
 # the akka-persistence-snapshot-store in use
 jdbc-snapshot-store {
-	tables {
-		# Only used in pre 5.0.0 for backward-compatibility
-		# ref: https://github.com/akka/akka-persistence-jdbc/blob/v5.0.0/core/src/main/resources/reference.conf
-		legacy_snapshot {
-			tableName = "snapshot"
-			schemaName = ${jdbc-default.schema}
+  tables {
+    # Only used in pre 5.0.0 for backward-compatibility
+    # ref: https://github.com/akka/akka-persistence-jdbc/blob/v5.0.0/core/src/main/resources/reference.conf
+    legacy_snapshot {
+      tableName = "snapshot"
+      schemaName = ${jdbc-default.schema}
 
-			columnNames {
-				persistenceId = "persistence_id"
-				sequenceNumber = "sequence_number"
-				created = "created"
-				snapshot = "snapshot"
-			}
-		}
+      columnNames {
+        persistenceId = "persistence_id"
+        sequenceNumber = "sequence_number"
+        created = "created"
+        snapshot = "snapshot"
+      }
+    }
 
-		# This is the new configuration going forward
-		snapshot {
-			tableName = "state_snapshot"
-			schemaName = ${jdbc-default.schema}
-			columnNames {
-				persistenceId = "persistence_id"
-				sequenceNumber = "sequence_number"
-				created = "created"
+    # This is the new configuration going forward
+    snapshot {
+      tableName = "state_snapshot"
+      schemaName = ${jdbc-default.schema}
+      columnNames {
+        persistenceId = "persistence_id"
+        sequenceNumber = "sequence_number"
+        created = "created"
 
-				snapshotPayload = "snapshot_payload"
-				snapshotSerId = "snapshot_ser_id"
-				snapshotSerManifest = "snapshot_ser_manifest"
+        snapshotPayload = "snapshot_payload"
+        snapshotSerId = "snapshot_ser_id"
+        snapshotSerManifest = "snapshot_ser_manifest"
 
-				metaPayload = "meta_payload"
-				metaSerId = "meta_ser_id"
-				metaSerManifest = "meta_ser_manifest"
-			}
-		}
-	}
-	dao = "akka.persistence.jdbc.snapshot.dao.DefaultSnapshotDao"
+        metaPayload = "meta_payload"
+        metaSerId = "meta_ser_id"
+        metaSerManifest = "meta_ser_manifest"
+      }
+    }
+  }
+  dao = "akka.persistence.jdbc.snapshot.dao.DefaultSnapshotDao"
 
-	slick = ${write-side-slick}
+  slick = ${write-side-slick}
 }

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/MigratorSpec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/MigratorSpec.scala
@@ -8,7 +8,7 @@ package com.namely.chiefofstate.migration
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
-import com.namely.chiefofstate.migration.helper.TestConfig
+import com.namely.chiefofstate.migration.helper.{ DbHelper, TestConfig }
 import com.namely.chiefofstate.migration.helper.TestConfig.dbConfigFromUrl
 import org.testcontainers.utility.DockerImageName
 import slick.basic.DatabaseConfig
@@ -20,7 +20,6 @@ import java.sql.DriverManager
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.Success
-import com.namely.chiefofstate.migration.helper.DbHelper
 
 class MigratorSpec extends BaseSpec with ForAllTestContainer {
 

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/helper/DbHelper.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/helper/DbHelper.scala
@@ -6,10 +6,10 @@
 
 package com.namely.chiefofstate.migration.helper
 
+import com.dimafeng.testcontainers.PostgreSQLContainer
 import com.namely.protobuf.chiefofstate.v1.persistence.{ EventWrapper, StateWrapper }
-import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
+
 import java.sql.{ Connection, DriverManager }
-import org.checkerframework.checker.units.qual.s
 
 object DbHelper {
   val serializerId = 5001

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v1/V1Spec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v1/V1Spec.scala
@@ -8,9 +8,10 @@ package com.namely.chiefofstate.migration.versions.v1
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import com.dimafeng.testcontainers.{ ForAllTestContainer, MultipleContainers, PostgreSQLContainer }
-import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil }
+import com.namely.chiefofstate.migration.helper.DbHelper._
 import com.namely.chiefofstate.migration.helper.TestConfig
 import com.namely.chiefofstate.migration.versions.v1.V1.{ createTable, insertInto, tempTable, OffsetRow }
+import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil }
 import com.typesafe.config.Config
 import org.testcontainers.utility.DockerImageName
 import slick.basic.DatabaseConfig
@@ -19,11 +20,9 @@ import slick.jdbc.JdbcProfile
 import slick.jdbc.PostgresProfile.api._
 import slick.sql.SqlStreamingAction
 
-import java.sql.{ Connection, DriverManager }
 import java.time.Instant
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import com.namely.chiefofstate.migration.helper.DbHelper._
 
 class V1Spec extends BaseSpec with ForAllTestContainer {
 

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/MigrateJournalSpec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/MigrateJournalSpec.scala
@@ -17,12 +17,12 @@ import com.namely.protobuf.chiefofstate.v1.persistence.EventWrapper
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import org.testcontainers.utility.DockerImageName
 import slick.basic.DatabaseConfig
-import slick.jdbc.{ JdbcBackend, JdbcProfile }
 import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.{ JdbcBackend, JdbcProfile }
 
 import java.sql.{ Connection, DriverManager }
-import scala.concurrent.{ Await, ExecutionContextExecutor, Future }
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, ExecutionContextExecutor, Future }
 
 class MigrateJournalSpec extends BaseSpec with ForAllTestContainer {
 

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/MigrateSnapshotSpec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/MigrateSnapshotSpec.scala
@@ -18,12 +18,12 @@ import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil, JdbcConfig, Schemas
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import org.testcontainers.utility.DockerImageName
 import slick.basic.DatabaseConfig
-import slick.jdbc.{ JdbcBackend, JdbcProfile }
 import slick.jdbc.PostgresProfile.api._
+import slick.jdbc.{ JdbcBackend, JdbcProfile }
 
 import java.sql.{ Connection, DriverManager }
-import scala.concurrent.{ Await, ExecutionContextExecutor }
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, ExecutionContextExecutor }
 
 class MigrateSnapshotSpec extends BaseSpec with ForAllTestContainer {
   val cosSchema: String = "cos"

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/Seed.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/Seed.scala
@@ -6,9 +6,9 @@
 
 package com.namely.chiefofstate.migration.versions.v2
 
-import akka.persistence.{ PersistentRepr, SnapshotMetadata }
 import akka.persistence.jdbc.journal.dao.legacy
 import akka.persistence.jdbc.snapshot.dao.legacy.ByteArraySnapshotDao
+import akka.persistence.{ PersistentRepr, SnapshotMetadata }
 import akka.serialization.Serialization
 import com.namely.protobuf.chiefofstate.v1.persistence.EventWrapper
 import com.namely.protobuf.chiefofstate.v1.tests.{ Account, AccountOpened }
@@ -18,8 +18,8 @@ import slick.jdbc.PostgresProfile.api._
 
 import java.time.Instant
 import java.util.UUID
-import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, ExecutionContext, Future }
 
 object Seed {
   private def journalRows(serialization: Serialization, numRows: Int): Seq[legacy.JournalRow] = {

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/V2Spec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v2/V2Spec.scala
@@ -15,17 +15,16 @@ import akka.persistence.jdbc.snapshot.dao
 import akka.persistence.jdbc.snapshot.dao.legacy.{ ByteArraySnapshotDao, SnapshotQueries }
 import akka.serialization.{ Serialization, SerializationExtension }
 import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
+import com.namely.chiefofstate.migration.helper.DbHelper._
 import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil, JdbcConfig, SchemasUtil }
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import org.testcontainers.utility.DockerImageName
 import slick.basic.DatabaseConfig
-import slick.jdbc.{ JdbcBackend, JdbcProfile }
 import slick.jdbc.PostgresProfile.api._
-import com.namely.chiefofstate.migration.helper.DbHelper._
+import slick.jdbc.{ JdbcBackend, JdbcProfile }
 
-import java.sql.{ Connection, DriverManager }
-import scala.concurrent.{ Await, ExecutionContext, ExecutionContextExecutor, Future }
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, ExecutionContext, ExecutionContextExecutor, Future }
 
 class V2Spec extends BaseSpec with ForAllTestContainer {
 

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v3/V3Spec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v3/V3Spec.scala
@@ -7,17 +7,17 @@
 package com.namely.chiefofstate.migration.versions.v3
 
 import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
-import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil, SchemasUtil }
+import com.namely.chiefofstate.migration.helper.DbHelper._
 import com.namely.chiefofstate.migration.helper.TestConfig
+import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil, SchemasUtil }
 import org.testcontainers.utility.DockerImageName
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 
-import java.sql.{ Connection, DriverManager, ResultSet, Statement }
+import java.sql.{ ResultSet, Statement }
 import java.util.concurrent.ExecutionException
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import com.namely.chiefofstate.migration.helper.DbHelper._
 
 class V3Spec extends BaseSpec with ForAllTestContainer {
 

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v4/V4Spec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v4/V4Spec.scala
@@ -7,17 +7,16 @@
 package com.namely.chiefofstate.migration.versions.v4
 
 import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
-import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil, SchemasUtil }
+import com.namely.chiefofstate.migration.helper.DbHelper._
 import com.namely.chiefofstate.migration.helper.TestConfig
+import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil, SchemasUtil }
 import org.testcontainers.utility.DockerImageName
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 
-import java.sql.{ Connection, DriverManager }
 import java.util.UUID
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import com.namely.chiefofstate.migration.helper.DbHelper._
 
 class V4Spec extends BaseSpec with ForAllTestContainer {
 

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v5/V5Spec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v5/V5Spec.scala
@@ -6,22 +6,21 @@
 
 package com.namely.chiefofstate.migration.versions.v5
 
-import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil, SchemasUtil }
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
+import com.google.protobuf.any
 import com.namely.chiefofstate.migration.helper.{ DbHelper, TestConfig }
-import org.testcontainers.utility.DockerImageName
+import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil, SchemasUtil }
+import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.{ Header, Headers }
+import com.namely.protobuf.chiefofstate.v1.common.MetaData
+import com.namely.protobuf.chiefofstate.v1.persistence.{ EventWrapper, StateWrapper }
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
+import org.testcontainers.utility.DockerImageName
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
-import java.sql.{ Connection, DriverManager }
-import java.util.UUID
+
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import akka.actor.testkit.typed.scaladsl.ActorTestKit
-import com.namely.protobuf.chiefofstate.v1.persistence.{ EventWrapper, StateWrapper }
-import com.namely.protobuf.chiefofstate.v1.common.MetaData
-import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.{ Header, Headers }
-import com.google.protobuf.any
 
 class V5Spec extends BaseSpec with ForAllTestContainer {
 

--- a/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v6/V6Spec.scala
+++ b/code/migration/src/test/scala/com/namely/chiefofstate/migration/versions/v6/V6Spec.scala
@@ -6,14 +6,14 @@
 
 package com.namely.chiefofstate.migration.versions.v6
 import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
-import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil }
 import com.namely.chiefofstate.migration.helper.{ DbHelper, TestConfig }
+import com.namely.chiefofstate.migration.{ BaseSpec, DbUtil }
 import org.testcontainers.utility.DockerImageName
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 
-import scala.concurrent.duration.Duration
 import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 class V6Spec extends BaseSpec with ForAllTestContainer {
   val cosSchema: String = "cos"

--- a/code/service/src/main/resources/application.conf
+++ b/code/service/src/main/resources/application.conf
@@ -17,9 +17,13 @@ jdbc-default {
   hikari-settings {
     #FIXME - add env vars for all these settings
     max-pool-size = 10
+    max-pool-size = ${?COS_DB_POOL_MAX_SIZE}
     min-idle-connections = 3
+    min-idle-connections = ${?COS_DB_POOL_MIN_IDLE_CONNECTIONS}
     idle-timeout-ms = 30000 # 30 seconds
+    idle-timeout-ms = ${?COS_DB_POOL_IDLE_TIMEOUT_MS}
     max-lifetime-ms = 60000 # 60 seconds
+    max-lifetime-ms = ${?COS_DB_POOL_MAX_LIFETIME_MS}
   }
 }
 
@@ -423,46 +427,5 @@ chiefofstate {
 
     trace_propagators = "b3multi"
     trace_propagators = ${?COS_TRACE_PROPAGATORS}
-  }
-
-  # migration configuration
-  # This setting are required for a smooth migration to 0.8.0
-  migration {
-    v1 {
-      slick {
-        profile = "slick.jdbc.PostgresProfile$"
-        # add here your Slick db settings
-        db {
-          driver = "org.postgresql.Driver"
-          user = ${jdbc-default.user}
-          user = ${?COS_READ_SIDE_OFFSET_DB_USER}
-          password = ${jdbc-default.password}
-          password = ${?COS_READ_SIDE_OFFSET_DB_PASSWORD}
-          serverName = ${jdbc-default.host}
-          serverName = ${?COS_READ_SIDE_OFFSET_DB_HOST}
-          portNumber = ${jdbc-default.port}
-          portNumber = ${?COS_READ_SIDE_OFFSET_DB_PORT}
-          databaseName = ${jdbc-default.database}
-          databaseName = ${?COS_READ_SIDE_OFFSET_DB}
-          url = "jdbc:postgresql://"${chiefofstate.migration.v1.slick.db.serverName}":"${chiefofstate.migration.v1.slick.db.portNumber}"/"${chiefofstate.migration.v1.slick.db.databaseName}"?currentSchema="${chiefofstate.migration.v1.slick.offset-store.schema}
-          connectionPool = "HikariCP"
-          keepAliveConnection = false
-          # See some tips on thread/connection pool sizing on https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
-          # Keep in mind that the number of threads must equal the maximum number of connections.
-          numThreads = 5
-          maxConnections = 5
-          minConnections = 0
-          idleTimeout = 60000 # 60 seconds
-          maxLifetime = 120000 # 120 seconds
-        }
-        offset-store {
-          schema = ${jdbc-default.schema}
-          schema = ${?COS_READ_SIDE_OFFSET_DB_SCHEMA}
-          table = "read_side_offsets"
-          table = ${?COS_READ_SIDE_OFFSET_STORE_TABLE}
-          use-lowercase-schema = false
-        }
-      }
-    }
   }
 }

--- a/code/service/src/main/scala/com/namely/chiefofstate/AggregateRoot.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/AggregateRoot.scala
@@ -6,16 +6,16 @@
 
 package com.namely.chiefofstate
 
-import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl._
 import com.google.protobuf.any
 import com.google.protobuf.empty.Empty
-import com.namely.chiefofstate.config.{ CosConfig, SnapshotConfig }
 import com.namely.chiefofstate.Util.{ makeFailedStatusPf, toRpcStatus, Instants }
 import com.namely.chiefofstate.WriteHandlerHelpers.{ NewState, NoOp }
+import com.namely.chiefofstate.config.{ CosConfig, SnapshotConfig }
 import com.namely.chiefofstate.serialization.MessageWithActorRef
 import com.namely.protobuf.chiefofstate.v1.common.MetaData
 import com.namely.protobuf.chiefofstate.v1.internal.{ CommandReply, GetStateCommand, RemoteCommand, SendCommand }

--- a/code/service/src/main/scala/com/namely/chiefofstate/GrpcServiceImpl.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/GrpcServiceImpl.scala
@@ -15,12 +15,12 @@ import com.namely.chiefofstate.config.WriteSideConfig
 import com.namely.chiefofstate.serialization.MessageWithActorRef
 import com.namely.protobuf.chiefofstate.plugins.persistedheaders.v1.headers.{ Header => LegacyHeader, Headers }
 import com.namely.protobuf.chiefofstate.v1.common.Header
-import com.namely.protobuf.chiefofstate.v1.internal._
 import com.namely.protobuf.chiefofstate.v1.internal.CommandReply.Reply
+import com.namely.protobuf.chiefofstate.v1.internal._
 import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
 import com.namely.protobuf.chiefofstate.v1.service._
-import io.grpc.{ Metadata, Status, StatusException }
 import io.grpc.protobuf.StatusProto
+import io.grpc.{ Metadata, Status, StatusException }
 import io.opentelemetry.context.Context
 import io.superflat.otel.tools.{ GrpcHeadersInterceptor, TracingHelpers }
 import org.slf4j.{ Logger, LoggerFactory }

--- a/code/service/src/main/scala/com/namely/chiefofstate/NettyHelper.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/NettyHelper.scala
@@ -6,8 +6,8 @@
 
 package com.namely.chiefofstate
 
-import io.grpc.netty.{ NegotiationType, NettyChannelBuilder }
 import io.grpc.netty.NegotiationType.{ PLAINTEXT, TLS }
+import io.grpc.netty.{ NegotiationType, NettyChannelBuilder }
 
 object NettyHelper {
 

--- a/code/service/src/main/scala/com/namely/chiefofstate/RemoteCommandHandler.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/RemoteCommandHandler.scala
@@ -7,11 +7,11 @@
 package com.namely.chiefofstate
 
 import com.namely.chiefofstate.config.GrpcConfig
-import com.namely.protobuf.chiefofstate.v1.internal.RemoteCommand
 import com.namely.protobuf.chiefofstate.v1.common.Header.Value
+import com.namely.protobuf.chiefofstate.v1.internal.RemoteCommand
 import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
-import com.namely.protobuf.chiefofstate.v1.writeside.{ HandleCommandRequest, HandleCommandResponse }
 import com.namely.protobuf.chiefofstate.v1.writeside.WriteSideHandlerServiceGrpc.WriteSideHandlerServiceBlockingStub
+import com.namely.protobuf.chiefofstate.v1.writeside.{ HandleCommandRequest, HandleCommandResponse }
 import io.grpc.Metadata
 import io.grpc.stub.MetadataUtils
 import org.slf4j.{ Logger, LoggerFactory }

--- a/code/service/src/main/scala/com/namely/chiefofstate/RemoteEventHandler.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/RemoteEventHandler.scala
@@ -9,8 +9,8 @@ package com.namely.chiefofstate
 import com.google.protobuf.any
 import com.namely.chiefofstate.config.GrpcConfig
 import com.namely.protobuf.chiefofstate.v1.common.MetaData
-import com.namely.protobuf.chiefofstate.v1.writeside.{ HandleEventRequest, HandleEventResponse }
 import com.namely.protobuf.chiefofstate.v1.writeside.WriteSideHandlerServiceGrpc.WriteSideHandlerServiceBlockingStub
+import com.namely.protobuf.chiefofstate.v1.writeside.{ HandleEventRequest, HandleEventResponse }
 import org.slf4j.{ Logger, LoggerFactory }
 
 import java.util.concurrent.TimeUnit

--- a/code/service/src/main/scala/com/namely/chiefofstate/ServiceBootstrapper.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/ServiceBootstrapper.scala
@@ -6,8 +6,8 @@
 
 package com.namely.chiefofstate
 
-import akka.actor.typed.{ ActorSystem, Behavior }
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ ActorSystem, Behavior }
 import akka.cluster.sharding.typed.scaladsl.{ ClusterSharding, Entity }
 import akka.persistence.typed.PersistenceId
 import akka.util.Timeout
@@ -20,8 +20,8 @@ import com.typesafe.config.Config
 import io.grpc._
 import io.grpc.netty.NettyServerBuilder
 import io.opentelemetry.api.GlobalOpenTelemetry
-import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.instrumentation.grpc.v1_5.GrpcTracing
+import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.superflat.otel.tools._
 import org.slf4j.{ Logger, LoggerFactory }
 

--- a/code/service/src/main/scala/com/namely/chiefofstate/StartNode.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/StartNode.scala
@@ -6,8 +6,8 @@
 
 package com.namely.chiefofstate
 
-import akka.actor.typed.ActorSystem
 import akka.NotUsed
+import akka.actor.typed.ActorSystem
 import com.namely.chiefofstate.config.BootConfig
 import com.typesafe.config.Config
 

--- a/code/service/src/main/scala/com/namely/chiefofstate/StartNodeBehaviour.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/StartNodeBehaviour.scala
@@ -6,12 +6,12 @@
 
 package com.namely.chiefofstate
 
+import akka.NotUsed
 import akka.actor.typed._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.cluster.typed.{ Cluster, ClusterSingleton, SingletonActor }
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
-import akka.NotUsed
 import com.namely.chiefofstate.serialization.{ MessageWithActorRef, ScalaMessage }
 import com.namely.protobuf.chiefofstate.v1.internal.DoMigration
 import com.typesafe.config.Config

--- a/code/service/src/main/scala/com/namely/chiefofstate/Util.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/Util.scala
@@ -10,8 +10,8 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.any.Any
 import com.google.protobuf.timestamp.Timestamp
 import com.namely.protobuf.chiefofstate.v1.common.Header
-import io.grpc.{ Metadata, Status, StatusException, StatusRuntimeException }
 import io.grpc.protobuf.StatusProto
+import io.grpc.{ Metadata, Status, StatusException, StatusRuntimeException }
 
 import java.time.{ Instant, LocalDate, ZoneId }
 import scala.collection.mutable

--- a/code/service/src/main/scala/com/namely/chiefofstate/readside/ReadSideHandler.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/readside/ReadSideHandler.scala
@@ -7,8 +7,8 @@
 package com.namely.chiefofstate.readside
 
 import com.namely.protobuf.chiefofstate.v1.common.MetaData
-import com.namely.protobuf.chiefofstate.v1.readside.{ HandleReadSideRequest, HandleReadSideResponse }
 import com.namely.protobuf.chiefofstate.v1.readside.ReadSideHandlerServiceGrpc.ReadSideHandlerServiceBlockingStub
+import com.namely.protobuf.chiefofstate.v1.readside.{ HandleReadSideRequest, HandleReadSideResponse }
 import io.grpc.Metadata
 import io.grpc.stub.MetadataUtils
 import io.opentelemetry.api.GlobalOpenTelemetry

--- a/code/service/src/main/scala/com/namely/chiefofstate/readside/ReadSideJdbcHandler.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/readside/ReadSideJdbcHandler.scala
@@ -7,15 +7,12 @@
 package com.namely.chiefofstate.readside
 
 import akka.projection.eventsourced.EventEnvelope
-import akka.projection.jdbc.scaladsl.JdbcHandler
 import akka.projection.jdbc.JdbcSession
+import akka.projection.jdbc.scaladsl.JdbcHandler
 import com.google.protobuf.any.{ Any => ProtoAny }
 import com.namely.protobuf.chiefofstate.v1.common.MetaData
 import com.namely.protobuf.chiefofstate.v1.persistence.EventWrapper
-import com.namely.protobuf.chiefofstate.v1.readside.HandleReadSideResponse
 import org.slf4j.{ Logger, LoggerFactory }
-
-import scala.util.{ Failure, Success, Try }
 
 /**
  * Implements the akka JdbcHandler interface and forwards events to the

--- a/code/service/src/main/scala/com/namely/chiefofstate/readside/ReadSideProjection.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/readside/ReadSideProjection.scala
@@ -17,8 +17,9 @@ import akka.projection.jdbc.scaladsl.JdbcProjection
 import akka.projection.scaladsl.SourceProvider
 import akka.projection.{ ProjectionBehavior, ProjectionId }
 import com.namely.protobuf.chiefofstate.v1.persistence.EventWrapper
-import javax.sql.DataSource
 import org.slf4j.{ Logger, LoggerFactory }
+
+import javax.sql.DataSource
 
 /**
  * Read side processor creates a sharded daemon process for handling

--- a/code/service/src/main/scala/com/namely/chiefofstate/serialization/CosSerializer.scala
+++ b/code/service/src/main/scala/com/namely/chiefofstate/serialization/CosSerializer.scala
@@ -7,8 +7,8 @@
 package com.namely.chiefofstate.serialization
 
 import akka.actor.ExtendedActorSystem
-import akka.actor.typed.{ ActorRef, ActorRefResolver }
 import akka.actor.typed.scaladsl.adapter._
+import akka.actor.typed.{ ActorRef, ActorRefResolver }
 import akka.serialization.SerializerWithStringManifest
 import com.google.protobuf.{ any, ByteString }
 import com.namely.protobuf.chiefofstate.v1.internal.WireMessageWithActorRef

--- a/code/service/src/test/scala/com/namely/chiefofstate/AggregrateRootSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/AggregrateRootSpec.scala
@@ -16,22 +16,22 @@ import com.namely.chiefofstate.config.CosConfig
 import com.namely.chiefofstate.helper.BaseActorSpec
 import com.namely.chiefofstate.serialization.MessageWithActorRef
 import com.namely.protobuf.chiefofstate.v1.common.{ Header, MetaData }
-import com.namely.protobuf.chiefofstate.v1.internal._
 import com.namely.protobuf.chiefofstate.v1.internal.CommandReply.Reply
+import com.namely.protobuf.chiefofstate.v1.internal._
 import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
 import com.namely.protobuf.chiefofstate.v1.tests.{ Account, AccountOpened, OpenAccount }
-import com.namely.protobuf.chiefofstate.v1.writeside._
 import com.namely.protobuf.chiefofstate.v1.writeside.WriteSideHandlerServiceGrpc.WriteSideHandlerServiceBlockingStub
+import com.namely.protobuf.chiefofstate.v1.writeside._
 import com.typesafe.config.{ Config, ConfigFactory }
-import io.grpc.{ ManagedChannel, ServerServiceDefinition, Status }
 import io.grpc.inprocess._
+import io.grpc.{ ManagedChannel, ServerServiceDefinition, Status }
 import scalapb.GeneratedMessage
 
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext.global
-import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.util.{ Failure, Try }
 
 class AggregrateRootSpec extends BaseActorSpec(s"""

--- a/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/GrpcServiceImplSpec.scala
@@ -11,8 +11,8 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.cluster.sharding.typed.javadsl.{ ClusterSharding => ClusterShardingJava }
 import akka.cluster.sharding.typed.scaladsl.{ ClusterSharding, EntityRef, EntityTypeKey }
 import akka.cluster.sharding.typed.testkit.scaladsl.TestEntityRef
-import com.google.protobuf.{ any, ByteString }
 import com.google.protobuf.wrappers.StringValue
+import com.google.protobuf.{ any, ByteString }
 import com.google.rpc.code
 import com.google.rpc.error_details.BadRequest
 import com.google.rpc.status.Status
@@ -23,16 +23,16 @@ import com.namely.protobuf.chiefofstate.v1.common.{ Header, MetaData }
 import com.namely.protobuf.chiefofstate.v1.internal.{ CommandReply, RemoteCommand, SendCommand }
 import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
 import com.namely.protobuf.chiefofstate.v1.service.{ ChiefOfStateServiceGrpc, GetStateRequest, ProcessCommandRequest }
-import io.grpc.{ ManagedChannel, Metadata, StatusException }
 import io.grpc.Status.Code
 import io.grpc.inprocess.{ InProcessChannelBuilder, InProcessServerBuilder }
 import io.grpc.protobuf.StatusProto
 import io.grpc.stub.MetadataUtils
+import io.grpc.{ ManagedChannel, Metadata, StatusException }
 import io.superflat.otel.tools.GrpcHeadersInterceptor
 
 import java.util.concurrent.TimeUnit
-import scala.concurrent.{ Await, ExecutionContext }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.concurrent.{ Await, ExecutionContext }
 import scala.util.Success
 
 class GrpcServiceImplSpec extends BaseActorSpec(s"""

--- a/code/service/src/test/scala/com/namely/chiefofstate/ProtosValidatorSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/ProtosValidatorSpec.scala
@@ -10,7 +10,6 @@ import com.google.protobuf.any.Any
 import com.namely.chiefofstate.config._
 import com.namely.chiefofstate.helper.BaseSpec
 import com.namely.protobuf.chiefofstate.v1.tests.{ Account, AccountOpened }
-import com.typesafe.config.{ Config, ConfigFactory }
 
 class ProtosValidatorSpec extends BaseSpec {
 

--- a/code/service/src/test/scala/com/namely/chiefofstate/RemoteCommandHandlerSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/RemoteCommandHandlerSpec.scala
@@ -6,23 +6,23 @@
 
 package com.namely.chiefofstate
 
-import com.google.protobuf.any.Any
 import com.google.protobuf.ByteString
+import com.google.protobuf.any.Any
 import com.namely.chiefofstate.config.{ GrpcClient, GrpcConfig, GrpcServer }
 import com.namely.chiefofstate.helper.BaseSpec
-import com.namely.protobuf.chiefofstate.v1.internal.RemoteCommand
 import com.namely.protobuf.chiefofstate.v1.common.Header
 import com.namely.protobuf.chiefofstate.v1.common.Header.Value
+import com.namely.protobuf.chiefofstate.v1.internal.RemoteCommand
 import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
 import com.namely.protobuf.chiefofstate.v1.tests.{ Account, AccountOpened, OpenAccount }
+import com.namely.protobuf.chiefofstate.v1.writeside.WriteSideHandlerServiceGrpc.WriteSideHandlerServiceBlockingStub
 import com.namely.protobuf.chiefofstate.v1.writeside.{
   HandleCommandRequest,
   HandleCommandResponse,
   WriteSideHandlerServiceGrpc
 }
-import com.namely.protobuf.chiefofstate.v1.writeside.WriteSideHandlerServiceGrpc.WriteSideHandlerServiceBlockingStub
-import io.grpc.{ ManagedChannel, ServerServiceDefinition, Status }
 import io.grpc.inprocess._
+import io.grpc.{ ManagedChannel, ServerServiceDefinition, Status }
 
 import scala.concurrent.ExecutionContext.global
 import scala.util.Try

--- a/code/service/src/test/scala/com/namely/chiefofstate/RemoteEventHandlerSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/RemoteEventHandlerSpec.scala
@@ -12,14 +12,14 @@ import com.namely.chiefofstate.helper.BaseSpec
 import com.namely.protobuf.chiefofstate.v1.common.MetaData
 import com.namely.protobuf.chiefofstate.v1.persistence.StateWrapper
 import com.namely.protobuf.chiefofstate.v1.tests.{ Account, AccountOpened }
+import com.namely.protobuf.chiefofstate.v1.writeside.WriteSideHandlerServiceGrpc.WriteSideHandlerServiceBlockingStub
 import com.namely.protobuf.chiefofstate.v1.writeside.{
   HandleEventRequest,
   HandleEventResponse,
   WriteSideHandlerServiceGrpc
 }
-import com.namely.protobuf.chiefofstate.v1.writeside.WriteSideHandlerServiceGrpc.WriteSideHandlerServiceBlockingStub
-import io.grpc.{ ManagedChannel, ServerServiceDefinition, Status }
 import io.grpc.inprocess._
+import io.grpc.{ ManagedChannel, ServerServiceDefinition, Status }
 
 import scala.concurrent.ExecutionContext.global
 import scala.util.Try

--- a/code/service/src/test/scala/com/namely/chiefofstate/ServiceMigrationRunnerSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/ServiceMigrationRunnerSpec.scala
@@ -20,8 +20,8 @@ import scalapb.GeneratedMessage
 
 import java.sql.{ Connection, DriverManager, Statement }
 import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.concurrent.Await
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 class ServiceMigrationRunnerSpec extends BaseSpec with ForAllTestContainer {
   val cosSchema: String = "cos"

--- a/code/service/src/test/scala/com/namely/chiefofstate/UtilSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/UtilSpec.scala
@@ -6,19 +6,19 @@
 
 package com.namely.chiefofstate
 
+import com.google.protobuf.ByteString
 import com.google.protobuf.timestamp.Timestamp
 import com.google.rpc.error_details.BadRequest
 import com.namely.chiefofstate.Util.{ Instants, Timestamps }
 import com.namely.chiefofstate.helper.BaseSpec
-import com.namely.protobuf.chiefofstate.v1.tests.AccountOpened
-import io.grpc.{ Metadata, Status, StatusException, StatusRuntimeException }
-import io.grpc.protobuf.StatusProto
 import com.namely.protobuf.chiefofstate.v1.common.Header
 import com.namely.protobuf.chiefofstate.v1.common.Header.Value.{ BytesValue, StringValue }
+import com.namely.protobuf.chiefofstate.v1.tests.AccountOpened
+import io.grpc.protobuf.StatusProto
+import io.grpc.{ Metadata, Status, StatusException, StatusRuntimeException }
 
 import java.time.{ Instant, ZoneId }
 import scala.util.Failure
-import com.google.protobuf.ByteString
 
 class UtilSpec extends BaseSpec {
   "A protobuf Timestamp date" should {

--- a/code/service/src/test/scala/com/namely/chiefofstate/helper/AwaitHelper.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/helper/AwaitHelper.scala
@@ -7,8 +7,8 @@
 package com.namely.chiefofstate.helper
 
 import java.util.concurrent.Executors
-import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, ExecutionContext, Future }
 
 /**
  * test helper to await some condition

--- a/code/service/src/test/scala/com/namely/chiefofstate/helper/BaseActorSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/helper/BaseActorSpec.scala
@@ -6,8 +6,8 @@
 
 package com.namely.chiefofstate.helper
 
-import akka.actor.testkit.typed.scaladsl.{ ActorTestKit, ActorTestKitBase }
 import akka.actor.testkit.typed.TestKitSettings
+import akka.actor.testkit.typed.scaladsl.{ ActorTestKit, ActorTestKitBase }
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.time.Span
 

--- a/code/service/src/test/scala/com/namely/chiefofstate/readside/ReadSideHandlerImplSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/readside/ReadSideHandlerImplSpec.scala
@@ -8,29 +8,26 @@ package com.namely.chiefofstate.readside
 
 import com.namely.chiefofstate.helper.BaseSpec
 import com.namely.protobuf.chiefofstate.v1.common.MetaData
+import com.namely.protobuf.chiefofstate.v1.readside.ReadSideHandlerServiceGrpc.ReadSideHandlerServiceBlockingStub
 import com.namely.protobuf.chiefofstate.v1.readside.{
   HandleReadSideRequest,
   HandleReadSideResponse,
   ReadSideHandlerServiceGrpc
 }
-import com.namely.protobuf.chiefofstate.v1.readside.ReadSideHandlerServiceGrpc.ReadSideHandlerServiceBlockingStub
 import com.namely.protobuf.chiefofstate.v1.tests.{ Account, AccountOpened }
 import io.grpc.Status
 import io.grpc.inprocess._
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.api.{ GlobalOpenTelemetry, OpenTelemetry }
-import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.sdk.OpenTelemetrySdk
-import io.opentelemetry.sdk.trace.data.SpanData
-
-import scala.jdk.CollectionConverters.ListHasAsScala
-import scala.concurrent.ExecutionContext.global
-import scala.concurrent.Future
-import scala.util.{ Failure, Success, Try }
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
-import io.opentelemetry.context.propagation.ContextPropagators
-import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
-import io.grpc.StatusRuntimeException
+
+import scala.concurrent.ExecutionContext.global
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters.ListHasAsScala
 
 class ReadSideHandlerImplSpec extends BaseSpec {
 

--- a/code/service/src/test/scala/com/namely/chiefofstate/readside/ReadSideJdbcHandlerSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/readside/ReadSideJdbcHandlerSpec.scala
@@ -6,17 +6,18 @@
 
 package com.namely.chiefofstate.readside
 
-import com.namely.chiefofstate.helper.BaseSpec
-import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
-import org.testcontainers.utility.DockerImageName
-import java.sql.{ Connection, DriverManager }
-import akka.projection.jdbc.JdbcSession
-import akka.projection.eventsourced.EventEnvelope
-import com.namely.protobuf.chiefofstate.v1.persistence.EventWrapper
 import akka.persistence.query.Offset
-import com.namely.protobuf.chiefofstate.v1.common.MetaData
+import akka.projection.eventsourced.EventEnvelope
+import akka.projection.jdbc.JdbcSession
+import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
 import com.google.protobuf.any
 import com.google.protobuf.wrappers.StringValue
+import com.namely.chiefofstate.helper.BaseSpec
+import com.namely.protobuf.chiefofstate.v1.common.MetaData
+import com.namely.protobuf.chiefofstate.v1.persistence.EventWrapper
+import org.testcontainers.utility.DockerImageName
+
+import java.sql.{ Connection, DriverManager }
 
 class ReadSideJdbcHandlerSpec extends BaseSpec with ForAllTestContainer {
 

--- a/code/service/src/test/scala/com/namely/chiefofstate/readside/ReadSideManagerSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/readside/ReadSideManagerSpec.scala
@@ -6,11 +6,11 @@
 
 package com.namely.chiefofstate.readside
 
-import com.namely.chiefofstate.helper.BaseSpec
-import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
-import org.testcontainers.utility.DockerImageName
-import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
+import com.namely.chiefofstate.helper.BaseSpec
+import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
+import org.testcontainers.utility.DockerImageName
 
 class ReadSideManagerSpec extends BaseSpec with ForAllTestContainer {
 

--- a/code/service/src/test/scala/com/namely/chiefofstate/readside/ReadSideProjectionSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/readside/ReadSideProjectionSpec.scala
@@ -6,11 +6,11 @@
 
 package com.namely.chiefofstate.readside
 
-import com.namely.chiefofstate.helper.BaseSpec
-import javax.sql.DataSource
-import akka.actor.typed.ActorSystem
-import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import com.namely.chiefofstate.helper.BaseSpec
+import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
+
+import javax.sql.DataSource
 
 class ReadSideProjectionSpec extends BaseSpec {
   lazy val config: Config = ConfigFactory

--- a/code/service/src/test/scala/com/namely/chiefofstate/serialization/CosSerializerSpec.scala
+++ b/code/service/src/test/scala/com/namely/chiefofstate/serialization/CosSerializerSpec.scala
@@ -6,19 +6,19 @@
 
 package com.namely.chiefofstate.serialization
 
+import akka.actor.ExtendedActorSystem
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.scaladsl.adapter._
-import akka.actor.ExtendedActorSystem
 import com.google.protobuf.any.Any
 import com.google.protobuf.wrappers.StringValue
 import com.namely.chiefofstate.helper.BaseActorSpec
+import com.namely.protobuf.chiefofstate.v1.common.Header
 import com.namely.protobuf.chiefofstate.v1.internal.{
   GetStateCommand,
   RemoteCommand,
   SendCommand,
   WireMessageWithActorRef
 }
-import com.namely.protobuf.chiefofstate.v1.common.Header
 import com.namely.protobuf.chiefofstate.v1.tests.OpenAccount
 import scalapb.GeneratedMessage
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,10 @@ See the following deployment-specific guides for relevant configurations:
 | COS_DB_PORT | journal, snapshot and read side offsets store port | 5432 |
 | COS_DB_NAME | journal, snapshot and read side offsets store db name | postgres |
 | COS_DB_SCHEMA | journal, snapshot and read side offsets store db schema | public |
+| COS_DB_POOL_MAX_SIZE |  controls the maximum size that the pool is allowed to reach, including both idle and in-use connections | 10 |
+| COS_DB_POOL_MIN_IDLE_CONNECTIONS | controls the minimum number of idle connections to maintain in the pool | 3 |
+| COS_DB_POOL_IDLE_TIMEOUT_MS | controls the maximum amount of time in milliseconds that a connection is allowed to sit idle in the pool | 30000 |
+| COS_DB_POOL_MAX_LIFETIME_MS | controls the maximum lifetime of a connection in the pool | 60000 |
 | COS_SNAPSHOT_FREQUENCY |Save snapshots automatically every Number of Events| 100 |
 | COS_NUM_SNAPSHOTS_TO_RETAIN | Number of Aggregate Snapshot to persist to disk for swift recovery | 2 |
 | COS_READ_SIDE_ENABLED | turn on readside or not | false |


### PR DESCRIPTION
This PR features the following changes:

- Remove all migration config and code prior to 0.8.2
- Extract the COS db connection pool settings into env vars.
- Document the COS connection pool env vars
- Downgrade scalafmt to 3.0.2 due to an existing bug(The 3.0.4 should fix it)

@klvmungai We need to rollout this changes and cut a release tag because there have been so many dependencies updates since the last release. I can confidently say we can release 0.9.0 without any issue as long as everyone is on the 0.8.2