### PR TITLE
Issue-427 upgrade scala otel tool to 0.1.9

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
 
     val TestContainers: String = "0.39.8"
 
-    val OtelToolsVersion: String = "0.1.8"
+    val OtelToolsVersion: String = "0.1.9"
   }
 
   import Dependencies.Versions._


### PR DESCRIPTION
Upgrades scala otel tools to 0.1.9 to fix a COS metrics dependency issue.