### PR TITLE
[PG-2] Deprecating Codecov from repository

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Build
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          EARTHLY_SECRETS: "CODECOV_TOKEN"
           COMMIT_HASH: ${{ github.sha }}
           EARTHLY_BUILD_ARGS: "BRANCH_NAME,COMMIT_HASH"
           FORCE_COLOR: 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Build
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          EARTHLY_SECRETS: "CODECOV_TOKEN"
           COMMIT_HASH: ${{ github.sha }}
           EARTHLY_BUILD_ARGS: "BRANCH_NAME,COMMIT_HASH"
           FORCE_COLOR: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Build
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          EARTHLY_SECRETS: "CODECOV_TOKEN"
           EARTHLY_BUILD_ARGS: "BRANCH_NAME,COMMIT_HASH,VERSION"
           FORCE_COLOR: 1
           COMMIT_HASH: ${{ github.sha }}

--- a/Earthfile
+++ b/Earthfile
@@ -84,18 +84,8 @@ test-local:
     # push to earthly cache
     SAVE IMAGE --push namely/chief-of-state:earthly-cache
 
-codecov:
-    FROM +test-local
-    ARG COMMIT_HASH=""
-    ARG BRANCH_NAME=""
-    ARG BUILD_NUMBER=""
-    RUN curl -s https://codecov.io/bash > codecov.sh && chmod +x codecov.sh
-    RUN --secret CODECOV_TOKEN=+secrets/CODECOV_TOKEN \
-        ./codecov.sh -t "${CODECOV_TOKEN}" -B "${BRANCH_NAME}" -C "${COMMIT_HASH}" -b "${BUILD_NUMBER}"
-
 test-all:
     BUILD +test-local
-    BUILD +codecov
 
 sbt:
     # TODO: move this to a central image

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,6 @@
 
 [![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/namely/chief-of-state/Build/master?style=flat-square)](https://github.com/namely/chief-of-state/actions?query=workflow%3ABuild)
 [![Codacy grade](https://img.shields.io/codacy/grade/47a0f8ca3b614b32b1be2ec451c3e2e4?style=flat-square)](https://app.codacy.com/gh/namely/chief-of-state?utm_source=github.com&utm_medium=referral&utm_content=namely/chief-of-state&utm_campaign=Badge_Grade_Settings)
-[![Codecov](https://img.shields.io/codecov/c/github/namely/chief-of-state?color=red&style=flat-square)](https://codecov.io/gh/namely/chief-of-state)
 [![Docker Hub](https://img.shields.io/badge/docker%20hub-namely-blue?style=flat-square)](https://hub.docker.com/repository/docker/namely/chief-of-state)
 ![Docker Pulls](https://img.shields.io/docker/pulls/namely/chief-of-state?style=flat-square)
 


### PR DESCRIPTION

# What does this do?

This PR removes Codecov from this repository.

# Why are we doing this?

We are migrating our code coverage functionality over to [Codacy](https://app.codacy.com/organizations/gh/namely/dashboard). This new product also performs static code analysis and linting against any new commits or PRs.

**We have a deadline to complete this transition by the end of the month to avoid any interruptions in our build process as Codecov Uploader is scheduled to be sunset at the end of this month.**

Please drop in on the #codacy-discussion channel in Slack if you have any questions.